### PR TITLE
feat: convert vanilla mastery effects in skills to be incremental

### DIFF
--- a/mod_modular_vanilla/hooks/skills/actives/aimed_shot.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/aimed_shot.nut
@@ -1,0 +1,27 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/aimed_shot", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInBows)
+		{
+			this.m.MaxRange += 1;
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/actives/aimed_shot", function(q) {
+		q.onAdded = @(__original) function()
+		{
+			local weapon = this.getItem();
+			if (!::MSU.isNull(weapon))
+			{
+				this.setBaseValue("MaxRange", weapon.getRangeMax());
+			}
+
+			__original();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/actives/bash.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/bash.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/bash", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInMaces)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/batter_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/batter_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/batter_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInHammers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/cascade_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/cascade_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/cascade_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInFlails)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/chop.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/chop.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/chop", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInAxes)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/cleave.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/cleave.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/cleave", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCleavers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/crumble_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/crumble_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/crumble_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInMaces)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/crush_armor.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/crush_armor.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/crush_armor", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInHammers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/cudgel_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/cudgel_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/cudgel_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInMaces)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/deathblow_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/deathblow_skill.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/deathblow_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInDaggers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 1)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/decapitate.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/decapitate.nut
@@ -1,0 +1,17 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/decapitate", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (this.m.ApplySwordMastery)
+		{
+			if (_properties.IsSpecializedInSwords)
+			{
+				this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			}
+		}
+		else if (_properties.IsSpecializedInCleavers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/demolish_armor_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/demolish_armor_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/demolish_armor_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInHammers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/disarm_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/disarm_skill.nut
@@ -1,0 +1,22 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/disarm_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCleavers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			this.m.HitChanceBonus += 10;
+		}
+	}
+});
+
+::ModularVanilla.QueueBucket.Normal.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/actives/shoot_bolt", function(q) {
+		// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+		q.softReset = @(__original) function()
+		{
+			__original();
+			this.resetField("HitChanceBonus");
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/actives/fire_handgonne_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/fire_handgonne_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/fire_handgonne_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCrossbows)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/flail_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/flail_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/flail_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInFlails)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/footwork.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/footwork.nut
@@ -1,0 +1,18 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/footwork", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsFleetfooted)
+		{
+			this.m.FatigueCostMult *= 0.5;
+
+			if (this.getContainer().hasSkill("effects.goblin_grunt_potion"))
+			{
+				if (this.m.ActionPointCost > 2)
+				{
+					this.m.ActionPointCost -= 2;
+				}
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/gash_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/gash_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/gash_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/ghost_overhead_strike.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/ghost_overhead_strike.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/ghost_overhead_strike", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/ghost_split_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/ghost_split_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/ghost_split_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/ghost_swing_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/ghost_swing_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/ghost_swing_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/hail_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/hail_skill.nut
@@ -1,0 +1,13 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/hail_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInFlails)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			this.m.IsShieldRelevant = false;
+		}
+
+		this.m.IsShieldRelevant = true;
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/hammer.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/hammer.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/hammer", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInHammers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/hook.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/hook.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/hook", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/ignite_firelance_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/ignite_firelance_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/ignite_firelance_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCrossbows)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/impale.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/impale.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/impale", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/knock_back.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/knock_back.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/knock_back", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsProficientWithShieldSkills)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/knock_out.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/knock_out.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/knock_out", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInMaces)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/knock_over_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/knock_over_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/knock_over_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInMaces)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/lash_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/lash_skill.nut
@@ -1,0 +1,13 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/lash_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInFlails)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			this.m.IsShieldRelevant = false;
+		}
+
+		this.m.IsShieldRelevant = true;
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/lunge_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/lunge_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/lunge_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/overhead_strike.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/overhead_strike.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/overhead_strike", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/pound.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/pound.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/pound", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInFlails)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/prong_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/prong_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/prong_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSpears)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/puncture.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/puncture.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/puncture", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInDaggers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 1)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/quick_shot.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/quick_shot.nut
@@ -1,0 +1,27 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/quick_shot", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInBows)
+		{
+			this.m.MaxRange += 1;
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/actives/quick_shot", function(q) {
+		q.onAdded = @(__original) function()
+		{
+			local weapon = this.getItem();
+			if (!::MSU.isNull(weapon))
+			{
+				this.setBaseValue("MaxRange", weapon.getRangeMax() - 1);
+			}
+
+			__original();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/actives/reap_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/reap_skill.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/reap_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/reload_bolt.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/reload_bolt.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/reload_bolt", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCrossbows)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/reload_handgonne_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/reload_handgonne_skill.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/reload_handgonne_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCrossbows)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			this.m.ActionPointCost -= 3;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/repel.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/repel.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/repel", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/riposte.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/riposte.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/riposte", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/rotation.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/rotation.nut
@@ -1,0 +1,18 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/rotation", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsFleetfooted)
+		{
+			this.m.FatigueCostMult *= 0.5;
+
+			if (this.getContainer().hasSkill("effects.goblin_grunt_potion"))
+			{
+				if (this.m.ActionPointCost > 2)
+				{
+					this.m.ActionPointCost -= 2;
+				}
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/round_swing.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/round_swing.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/round_swing", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInAxes)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/rupture.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/rupture.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/rupture", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/shatter_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/shatter_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/shatter_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInHammers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/shieldwall.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/shieldwall.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/shieldwall", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsProficientWithShieldWall || _properties.IsProficientWithShieldSkills)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/shoot_bolt.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/shoot_bolt.nut
@@ -1,0 +1,23 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/shoot_bolt", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInCrossbows)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			this.m.DirectDamageMult += 0.2;
+		}
+	}
+});
+
+::ModularVanilla.QueueBucket.Normal.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/actives/shoot_bolt", function(q) {
+		// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+		q.softReset = @(__original) function()
+		{
+			__original();
+			this.resetField("DirectDamageMult");
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/actives/shoot_stake.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/shoot_stake.nut
@@ -1,0 +1,23 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/shoot_stake", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInCrossbows)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			this.m.DirectDamageMult += 0.2;
+		}
+	}
+});
+
+::ModularVanilla.QueueBucket.Normal.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/actives/shoot_stake", function(q) {
+		// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+		q.softReset = @(__original) function()
+		{
+			__original();
+			this.resetField("DirectDamageMult");
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/actives/slash.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/slash.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/slash", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/slash_lightning.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/slash_lightning.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/slash_lightning", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/sling_stone_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/sling_stone_skill.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/sling_stone_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/smite_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/smite_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/smite_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInHammers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/spearwall.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/spearwall.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/spearwall", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSpears)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/split.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/split.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/split", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/split_axe.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/split_axe.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/split_axe", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInAxes)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/split_man.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/split_man.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/split_man", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInAxes)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/split_shield.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/split_shield.nut
@@ -1,0 +1,25 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/split_shield", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInAxes)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/actives/split_shield", function(q) {
+		q.onAdded = @(__original) function()
+		{
+			local weapon = this.getContainer().getActor().getMainhandItem();
+			if (weapon != null && weapon.getBlockedSlotType() != null)
+			{
+				this.setBaseValue("ActionPointCost", 6);
+			}
+
+			__original();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/actives/stab.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/stab.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/stab", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInDaggers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 1)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/strike_down_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/strike_down_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/strike_down_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInMaces)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/strike_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/strike_skill.nut
@@ -1,0 +1,21 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/strike_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (this.m.ApplyAxeMastery)
+		{
+			if (_properties.IsSpecializedInAxes)
+			{
+				this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			}
+		}
+		else if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.m.ActionPointCost > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/swing.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/swing.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/swing", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSwords)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/thresh.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/thresh.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/thresh", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInFlails)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_acid_flask.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_acid_flask.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_acid_flask", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_axe.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_axe.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_axe", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_balls.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_balls.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_balls", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_daze_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_daze_bomb_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_daze_bomb_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_fire_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_fire_bomb_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_fire_bomb_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_holy_water.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_holy_water.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_holy_water", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_javelin.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_javelin.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_javelin", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		this.m.AdditionalAccuracy = this.m.Item.getAdditionalAccuracy();
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_net.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_net.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_net", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_smoke_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_smoke_bomb_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_smoke_bomb_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_spear_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_spear_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_spear_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInThrowing)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/thrust.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/thrust.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_spear_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInSpears)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/actives/whip_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/whip_skill.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/throw_spear_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() function( _properties )
+	{
+		if (_properties.IsSpecializedInCleavers)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+		}
+	}
+});


### PR DESCRIPTION
MSU implements the [incremental changes](https://github.com/MSUTeam/MSU/wiki/Skill-Base-Values) system for skills but because Perks by default have a `SkillOrder` that is before active skills, changes made to an active skill's `FatigueCostMult` and `ActionPointCost` by perks end up getting overwritten by the active skill's `onAfterUpdate` function. The workaround for this is to have your perk's `SkillOrder` be later than active skills but this is a bad limitation.

This PR hooks all vanilla active skills and rewrites their `onAfterUpdate` functions to now apply the original vanilla changes in an incremental way.

Note: All hooks in this mod run by default in the `VeryEarly` bracket **before MSU**. This is because this mod is meant to represent the vanilla mod but in a modular state, which is then modified by other libraries/mods.