### PR TITLE
feat: add surround morale check type and extract from onMovementFinish

### DIFF
--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -1,0 +1,5 @@
+// Add a new morale check type for being surrounded. Is used during
+// actor.onMovementFinish
+::Const.MoraleCheckType.Surround <- ::Const.MoraleCheckType.len();
+::Const.CharacterProperties.MoraleCheckBravery.push(0);
+::Const.CharacterProperties.MoraleCheckBraveryMult.push(1.0);

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -398,4 +398,108 @@
 
 		return damage;
 	}
+
+	// Extraction of part of vanilla logic from actor.onMovementFinish
+	q.onMovementFinish_checkMorale <- function( _tile )
+	{
+		local numOfEnemiesAdjacentToMe = _tile.getZoneOfControlCountOtherThan(this.getAlliedFactions());
+
+		if (this.m.CurrentMovementType == this.Const.Tactical.MovementType.Default)
+		{
+			if (this.getMoraleState() != this.Const.MoraleState.Fleeing)
+			{
+				for (local i = 0; i < 6; i++)
+				{
+					if (!_tile.hasNextTile(i))
+						continue;
+
+					local otherTile = _tile.getNextTile(i);
+					if (!otherTile.IsOccupiedByActor)
+						continue;
+
+					local otherActor = otherTile.getEntity();
+					local numEnemies = otherTile.getZoneOfControlCountOtherThan(otherActor.getAlliedFactions());
+
+					if (otherActor.m.MaxEnemiesThisTurn < numEnemies && !otherActor.isAlliedWith(this))
+					{
+						local difficulty = this.Math.maxf(10.0, 50.0 - this.getXPValue() * 0.1);
+						// MV: Changed morale check type to the new added MV Surround type
+						otherActor.checkMorale(-1, difficulty, ::Const.MoraleCheckType.Surround);
+						otherActor.m.MaxEnemiesThisTurn = numEnemies;
+					}
+				}
+			}
+		}
+		else if (this.m.CurrentMovementType == this.Const.Tactical.MovementType.Involuntary)
+		{
+			if (this.m.MaxEnemiesThisTurn < numOfEnemiesAdjacentToMe)
+			{
+				local difficulty = 40.0;
+				// MV: Changed morale check type to the new added MV Surround type
+				this.checkMorale(-1, difficulty, ::Const.MoraleCheckType.Surround);
+			}
+		}
+	}
+
+	// MV: Modularized
+	q.onMovementFinish = @() function( _tile )
+	{
+		this.m.IsMoving = true;
+		this.updateVisibility(_tile, this.getCurrentProperties().getVision(), this.getFaction());
+
+		if (this.Tactical.TurnSequenceBar.getActiveEntity() != null && this.Tactical.TurnSequenceBar.getActiveEntity().getID() != this.getID())
+		{
+			this.Tactical.TurnSequenceBar.getActiveEntity().updateVisibilityForFaction();
+		}
+
+		this.setZoneOfControl(_tile, this.hasZoneOfControl());
+
+		if (!this.m.IsExertingZoneOfOccupation)
+		{
+			_tile.addZoneOfOccupation(this.getFaction());
+			this.m.IsExertingZoneOfOccupation = true;
+		}
+
+		if (this.Const.Tactical.TerrainEffect[_tile.Type].len() > 0 && !this.m.Skills.hasSkill(this.Const.Tactical.TerrainEffectID[_tile.Type]))
+		{
+			this.getSkills().add(this.new(this.Const.Tactical.TerrainEffect[_tile.Type]));
+		}
+
+		if (_tile.IsHidingEntity)
+		{
+			this.getSkills().add(this.new(this.Const.Movement.HiddenStatusEffect));
+		}
+
+		local numOfEnemiesAdjacentToMe = _tile.getZoneOfControlCountOtherThan(this.getAlliedFactions());
+
+		// MV: Extracted
+		this.onMovementFinish_checkMorale(_tile);
+
+		this.m.CurrentMovementType = this.Const.Tactical.MovementType.Default;
+		this.m.MaxEnemiesThisTurn = this.Math.max(1, numOfEnemiesAdjacentToMe);
+
+		if (this.isPlayerControlled() && this.getMoraleState() > this.Const.MoraleState.Breaking && this.getMoraleState() != this.Const.MoraleState.Ignore && (_tile.SquareCoords.X == 0 || _tile.SquareCoords.Y == 0 || _tile.SquareCoords.X == 31 || _tile.SquareCoords.Y == 31))
+		{
+			local change = this.getMoraleState() - this.Const.MoraleState.Breaking;
+			this.checkMorale(-change, -1000);
+		}
+
+		if (this.m.IsEmittingMovementSounds && this.Const.Tactical.TerrainMovementSound[_tile.Subtype].len() != 0)
+		{
+			local sound = this.Const.Tactical.TerrainMovementSound[_tile.Subtype][this.Math.rand(0, this.Const.Tactical.TerrainMovementSound[_tile.Subtype].len() - 1)];
+			this.Sound.play("sounds/" + sound.File, sound.Volume * this.Const.Sound.Volume.TacticalMovement * this.Math.rand(90, 100) * 0.01, this.getPos(), sound.Pitch * this.Math.rand(95, 105) * 0.01);
+		}
+
+		this.spawnTerrainDropdownEffect(_tile);
+
+		if (_tile.Properties.Effect != null && _tile.Properties.Effect.IsAppliedOnEnter)
+		{
+			_tile.Properties.Effect.Callback(_tile, this);
+		}
+
+		this.getSkills().update();
+		this.getItems().onMovementFinished();
+		this.setDirty(true);
+		this.m.IsMoving = false;
+	}
 });


### PR DESCRIPTION
- Add a new morale check type for being surrounded.
- Extract the morale check logic from onMovementFinish of actor into a new function.