### PR TITLE
feat: add interruption framework for removing effects from actors

### DIFF
--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -11,4 +11,4 @@
 	MV_DiversionDamageMult = 0.75
 });
 
-::Const.CharacterProperties.MV_IsImmuneToInterrupt <- false;
+::Const.CharacterProperties.MV_IsImmuneToSkillsInterruption <- false;

--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -10,3 +10,5 @@
 	MV_DiversionHitChanceAdd = -15,
 	MV_DiversionDamageMult = 0.75
 });
+
+::Const.CharacterProperties.MV_IsImmuneToInterrupt <- false;

--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -49,5 +49,5 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	// array, the morale state will not be set to that value..
 	MV_ForbiddenMoraleStates = [],
 
-	MV_IsImmuneToInterrupt = false
+	MV_IsImmuneToSkillsInterruption = false
 });

--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -47,7 +47,5 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	MV_MoraleCheckBraveryCallbacks = [],
 	// During actor.setMoraleState if the passed morale state is found in this
 	// array, the morale state will not be set to that value..
-	MV_ForbiddenMoraleStates = [],
-
-	MV_IsImmuneToSkillsInterruption = false
+	MV_ForbiddenMoraleStates = []
 });

--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -47,5 +47,7 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	MV_MoraleCheckBraveryCallbacks = [],
 	// During actor.setMoraleState if the passed morale state is found in this
 	// array, the morale state will not be set to that value..
-	MV_ForbiddenMoraleStates = []
+	MV_ForbiddenMoraleStates = [],
+
+	MV_IsImmuneToInterrupt = false
 });

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -48,6 +48,7 @@
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
 	// Part of the actor.MV_interrupt framework
+	// Cause an 'Interruption' on this actor. That is a new standardized event, which will remove some temporary skills on the target. In Vanilla those interruptible skills are shieldwall, riposte and spearwall
 	q.MV_interrupt <- function()
 	{
 		if (!this.getCurrentProperties().MV_IsImmuneToInterrupt)

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -48,11 +48,9 @@
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
 	// Part of the actor.interrupt framework
-	// If _offensive is true then interrupts offensive skills e.g. riposte, spearwall
-	// If _defensive is true then interrupts defensive skills e.g. shieldwall
-	q.interrupt <- function( _offensive = true, _defensive = true )
+	q.interrupt <- function()
 	{
-		this.getSkills().onActorInterrupted(_offensive, _defensive);
+		this.getSkills().onActorInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -50,7 +50,8 @@
 	// Part of the actor.MV_interrupt framework
 	q.MV_interrupt <- function()
 	{
-		this.getSkills().MV_onActorInterrupted();
+		if (!this.getCurrentProperties().MV_IsImmuneToInterrupt)
+			this.getSkills().MV_onActorInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -47,10 +47,10 @@
 
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
-	// Part of the actor.interrupt framework
-	q.interrupt <- function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_interrupt <- function()
 	{
-		this.getSkills().onActorInterrupted();
+		this.getSkills().MV_onActorInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -47,12 +47,12 @@
 
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
-	// Part of the actor.MV_interrupt framework
+	// Part of the actor.MV_interruptSkills framework
 	// Cause an 'Interruption' on this actor. That is a new standardized event, which will remove some temporary skills on the target. In Vanilla those interruptible skills are shieldwall, riposte and spearwall
-	q.MV_interrupt <- function()
+	q.MV_interruptSkills <- function()
 	{
-		if (!this.getCurrentProperties().MV_IsImmuneToInterrupt)
-			this.getSkills().MV_onActorInterrupted();
+		if (!this.getCurrentProperties().MV_IsImmuneToSkillsInterruption)
+			this.getSkills().MV_onSkillsInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -46,6 +46,15 @@
 });
 
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
+	// MV: Added
+	// Part of the actor.interrupt framework
+	// If _offensive is true then interrupts offensive skills e.g. riposte, spearwall
+	// If _defensive is true then interrupts defensive skills e.g. shieldwall
+	q.interrupt <- function( _offensive = true, _defensive = true )
+	{
+		this.getSkills().onActorInterrupted(_offensive, _defensive);
+	}
+	
 // part of affordability preview system START
 	// MV: Added
 	q.m.MV_IsDoingPreviewUpdate <- false;

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -64,8 +64,7 @@
 	// Cause an 'Interruption' on this actor. That is a new standardized event, which will remove some temporary skills on the target. In Vanilla those interruptible skills are shieldwall, riposte and spearwall
 	q.MV_interruptSkills <- function()
 	{
-		if (!this.getCurrentProperties().MV_IsImmuneToSkillsInterruption)
-			this.getSkills().MV_onSkillsInterrupted();
+		this.getSkills().MV_onSkillsInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -61,11 +61,9 @@
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
 	// Part of the actor.interrupt framework
-	// If _offensive is true then interrupts offensive skills e.g. riposte, spearwall
-	// If _defensive is true then interrupts defensive skills e.g. shieldwall
-	q.interrupt <- function( _offensive = true, _defensive = true )
+	q.interrupt <- function()
 	{
-		this.getSkills().onActorInterrupted(_offensive, _defensive);
+		this.getSkills().onActorInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -60,12 +60,12 @@
 
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
-	// Part of the actor.MV_interrupt framework
+	// Part of the actor.MV_interruptSkills framework
 	// Cause an 'Interruption' on this actor. That is a new standardized event, which will remove some temporary skills on the target. In Vanilla those interruptible skills are shieldwall, riposte and spearwall
-	q.MV_interrupt <- function()
+	q.MV_interruptSkills <- function()
 	{
-		if (!this.getCurrentProperties().MV_IsImmuneToInterrupt)
-			this.getSkills().MV_onActorInterrupted();
+		if (!this.getCurrentProperties().MV_IsImmuneToSkillsInterruption)
+			this.getSkills().MV_onSkillsInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -61,6 +61,7 @@
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
 	// Part of the actor.MV_interrupt framework
+	// Cause an 'Interruption' on this actor. That is a new standardized event, which will remove some temporary skills on the target. In Vanilla those interruptible skills are shieldwall, riposte and spearwall
 	q.MV_interrupt <- function()
 	{
 		if (!this.getCurrentProperties().MV_IsImmuneToInterrupt)

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -59,6 +59,15 @@
 });
 
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
+	// MV: Added
+	// Part of the actor.interrupt framework
+	// If _offensive is true then interrupts offensive skills e.g. riposte, spearwall
+	// If _defensive is true then interrupts defensive skills e.g. shieldwall
+	q.interrupt <- function( _offensive = true, _defensive = true )
+	{
+		this.getSkills().onActorInterrupted(_offensive, _defensive);
+	}
+	
 // part of affordability preview system START
 	// MV: Added
 	q.m.MV_IsDoingPreviewUpdate <- false;

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -60,10 +60,10 @@
 
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 	// MV: Added
-	// Part of the actor.interrupt framework
-	q.interrupt <- function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_interrupt <- function()
 	{
-		this.getSkills().onActorInterrupted();
+		this.getSkills().MV_onActorInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -63,7 +63,8 @@
 	// Part of the actor.MV_interrupt framework
 	q.MV_interrupt <- function()
 	{
-		this.getSkills().MV_onActorInterrupted();
+		if (!this.getCurrentProperties().MV_IsImmuneToInterrupt)
+			this.getSkills().MV_onActorInterrupted();
 	}
 	
 // part of affordability preview system START

--- a/mod_modular_vanilla/hooks/skills/effects/disarmed_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/disarmed_effect.nut
@@ -1,0 +1,15 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/effects/disarmed_effect", function(q) {
+		// Part of the actor.interrupt framework
+		// Because this effect doesn't remove shieldwall_effect, we don't want to catch it in auto-interrupt detection
+		// in skill_container.removeByID. Instead we trigger a manual interruption here for offensive effects only.
+		q.onAdded = @(__original) function()
+		{
+			__original();
+			if (!this.isGarbage())
+			{
+				this.getContainer().getActor().interrupt(true, false);
+			}
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/effects/disarmed_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/disarmed_effect.nut
@@ -1,15 +1,11 @@
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/effects/disarmed_effect", function(q) {
-		// Part of the actor.interrupt framework
-		// Because this effect doesn't remove shieldwall_effect, we don't want to catch it in auto-interrupt detection
-		// in skill_container.removeByID. Instead we trigger a manual interruption here for offensive effects only.
+		// MV: Changed
+		// Part of skill_container.onDisarmed event
 		q.onAdded = @(__original) function()
 		{
 			__original();
-			if (!this.isGarbage())
-			{
-				this.getContainer().getActor().interrupt(true, false);
-			}
+			this.getContainer().MV_onDisarmed();
 		}
 	});
 });

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,6 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted = @() function()
 	{
 		this.removeSelf();
 	}

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -4,4 +4,10 @@
 	{
 		this.removeSelf();
 	}
+	
+	// Part of the skill_container.MV_onDisarmed framework
+	q.MV_onDisarmed = @() function()
+	{
+		this.removeSelf();
+	}
 });

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,0 +1,8 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted = @() function( _offensive, _defensive )
+	{
+		if (_offensive)
+			this.removeSelf();
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,8 +1,7 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function( _offensive, _defensive )
+	q.onActorInterrupted = @() function()
 	{
-		if (_offensive)
-			this.removeSelf();
+		this.removeSelf();
 	}
 });

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,6 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted = @() function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted = @() function()
 	{
 		this.removeSelf();
 	}

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,4 +1,11 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted = @() function( _offensive, _defensive )
+	{
+		if (_offensive)
+			this.removeSelf();
+	}
+	
 	// MV: Added
 	// Part of modularization of actor.setMoraleState
 	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,9 +1,8 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function( _offensive, _defensive )
+	q.onActorInterrupted = @() function()
 	{
-		if (_offensive)
-			this.removeSelf();
+		this.removeSelf();
 	}
 	
 	// MV: Added

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -4,6 +4,12 @@
 	{
 		this.removeSelf();
 	}
+
+	// Part of the skill_container.MV_onDisarmed framework
+	q.MV_onDisarmed = @() function()
+	{
+		this.removeSelf();
+	}
 	
 	// MV: Added
 	// Part of modularization of actor.setMoraleState

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,8 +1,7 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function( _offensive, _defensive )
+	q.onActorInterrupted = @() function()
 	{
-		if (_defensive)
-			this.removeSelf();
+		this.removeSelf();
 	}
 });

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,6 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted = @() function()
 	{
 		this.removeSelf();
 	}

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,0 +1,8 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted = @() function( _offensive, _defensive )
+	{
+		if (_defensive)
+			this.removeSelf();
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,6 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted = @() function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted = @() function()
 	{
 		this.removeSelf();
 	}

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,9 +1,8 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function( _offensive, _defensive )
+	q.onActorInterrupted = @() function()
 	{
-		if (_defensive)
-			this.removeSelf();
+		this.removeSelf();
 	}
 	
 	// MV: Added

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,4 +1,11 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted = @() function( _offensive, _defensive )
+	{
+		if (_defensive)
+			this.removeSelf();
+	}
+	
 	// MV: Added
 	// Part of modularization of actor.setMoraleState
 	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -4,4 +4,10 @@
 	{
 		this.removeSelf();
 	}
+	
+	// Part of the skill_container.MV_onDisarmed framework
+	q.MV_onDisarmed = @() function()
+	{
+		this.removeSelf();
+	}
 });

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,6 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted = @() function()
 	{
 		this.removeSelf();
 	}

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,0 +1,8 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted = @() function( _offensive, _defensive )
+	{
+		if (_offensive)
+			this.removeSelf();
+	}
+});

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,6 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted = @() function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted = @() function()
 	{
 		this.removeSelf();
 	}

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,8 +1,7 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function( _offensive, _defensive )
+	q.onActorInterrupted = @() function()
 	{
-		if (_offensive)
-			this.removeSelf();
+		this.removeSelf();
 	}
 });

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,4 +1,11 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted = @() function( _offensive, _defensive )
+	{
+		if (_offensive)
+			this.removeSelf();
+	}
+	
 	// MV: Added
 	// Part of modularization of actor.setMoraleState
 	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,9 +1,8 @@
 ::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted = @() function( _offensive, _defensive )
+	q.onActorInterrupted = @() function()
 	{
-		if (_offensive)
-			this.removeSelf();
+		this.removeSelf();
 	}
 	
 	// MV: Added

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -4,6 +4,12 @@
 	{
 		this.removeSelf();
 	}
+
+	// Part of the skill_container.MV_onDisarmed framework
+	q.MV_onDisarmed = @() function()
+	{
+		this.removeSelf();
+	}
 	
 	// MV: Added
 	// Part of modularization of actor.setMoraleState

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -7,8 +7,8 @@
 	}
 
 	// MV: Added
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted <- function()
 	{
 	}
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -8,7 +8,14 @@
 
 	// MV: Added
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function( _offensive, _defensive )
+	q.onActorInterrupted <- function()
+	{
+	}
+
+	// MV: Added
+	// skill_container event that is triggered from onAdded of disarmed_effect
+	// but modders can also manually call this from other places as necessary.
+	q.MV_onDisarmed <- function()
 	{
 	}
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -7,6 +7,12 @@
 	}
 
 	// MV: Added
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted <- function( _offensive, _defensive )
+	{
+	}
+
+	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
 	q.MV_getDamageRegular <- function( _properties, _targetEntity = null )

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -7,8 +7,8 @@
 	}
 
 	// MV: Added
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted <- function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted <- function()
 	{
 	}
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -62,8 +62,8 @@
 	}}.MV_onMoraleStateChanged;
 
 	// MV: Added
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted <- function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted <- function()
 	{
 	}
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -62,6 +62,12 @@
 	}}.MV_onMoraleStateChanged;
 
 	// MV: Added
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted <- function( _offensive, _defensive )
+	{
+	}
+
+	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
 	q.MV_getDamageRegular <- { function MV_getDamageRegular( _properties, _targetEntity = null )

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -63,7 +63,14 @@
 
 	// MV: Added
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function( _offensive, _defensive )
+	q.onActorInterrupted <- function()
+	{
+	}
+
+	// MV: Added
+	// skill_container event that is triggered from onAdded of disarmed_effect
+	// but modders can also manually call this from other places as necessary.
+	q.MV_onDisarmed <- function()
 	{
 	}
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -62,8 +62,8 @@
 	}}.MV_onMoraleStateChanged;
 
 	// MV: Added
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted <- function()
 	{
 	}
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -18,8 +18,8 @@
 	}
 
 	// MV: Added
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted <- function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted <- function()
 	{
 		local wasUpdating = this.m.IsUpdating;
 		this.m.IsUpdating = true;
@@ -27,7 +27,7 @@
 		foreach (s in this.m.Skills)
 		{
 			if (!s.isGarbage())
-				s.MV_onActorInterrupted();
+				s.MV_onSkillsInterrupted();
 		}
 
 		this.m.IsUpdating = wasUpdating;
@@ -55,10 +55,10 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
-		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interrupt framework
-		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interrupt framework
+		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interruptSkills framework
+		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interruptSkills framework
 
-		// Part of actor.MV_interrupt framework
+		// Part of actor.MV_interruptSkills framework
 		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
 		// immediately one after the other i.e. it happens within a single frame. So we check if all 3 effects were
 		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
@@ -91,7 +91,7 @@
 			if (this.m.__MV_InterruptionCount == 3)
 			{
 				this.m.__MV_InterruptionCount = 0;
-				this.getActor().MV_interrupt();
+				this.getActor().MV_interruptSkills();
 			}
 		}
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -1,3 +1,7 @@
+// MV: Added
+// Part of the actor.interrupt framework
+::MSU.Skills.addEvent("onActorInterrupted", function( _offensive, _defensive ) {});
+
 ::ModularVanilla.MH.hook("scripts/skills/skill_container", function(q) {
 	// MV: Added
 	// part of player_party.updateStrength modularization
@@ -20,6 +24,46 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
+		q.m.MV_InterruptionFrame <- 0; // Part of the actor.interrupt framework
+		q.m.MV_InterruptionCount <- 0; // Part of the actor.interrupt framework
+
+		// Part of actor.interrupt framework
+		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
+		// immediately one after the other i.e. it happens within a single frame. So we check if all 3 effects were
+		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
+		// This is done instead of hooking every single vanilla file which triggers these kinds of interruptions.
+		// This implementation should also cover all mods which followed the vanilla style of removing those 3 effects only.
+		// An exception is the disarmed_effect which doesn't remove shieldwall. For that we hook that effect directly and do
+		// offensive interrupt only.
+		q.removeByID = @(__original) function( _skillID )
+		{
+			switch (_skillID)
+			{
+				case "effects.shieldwall":
+				case "effects.spearwall":
+				case "effects.riposte":
+					local frame = ::Time.getFrame();
+					if (frame != this.m.MV_InterruptionFrame)
+					{
+						this.m.MV_InterruptionCount = 0;
+						this.m.MV_InterruptionFrame = frame;
+					}
+					else
+					{
+						this.m.MV_InterruptionCount++;
+					}
+					break;
+			}
+
+			__original(_skillID);
+
+			if (this.m.MV_InterruptionCount >= 2)
+			{
+				this.m.MV_InterruptionCount = 0;
+				this.getActor().interrupt();
+			}
+		}
+
 		// MV: Changed
 		// part of affordability preview system
 		// Prevent collectGarbage from running during a preview type skill_container.update

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -1,7 +1,3 @@
-// MV: Added
-// Part of the actor.interrupt framework
-::MSU.Skills.addEvent("onActorInterrupted", function( _offensive, _defensive ) {});
-
 ::ModularVanilla.MH.hook("scripts/skills/skill_container", function(q) {
 	// MV: Added
 	// part of player_party.updateStrength modularization
@@ -19,6 +15,23 @@
 		this.m.IsUpdating = wasUpdating;
 
 		return ret;
+	}
+
+	// MV: Added
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted <- function( _offensive, _defensive )
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+				s.onActorInterrupted(_offensive, _defensive);
+		}
+
+		this.m.IsUpdating = wasUpdating;
+		this.update();
 	}
 });
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -18,8 +18,8 @@
 	}
 
 	// MV: Added
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted <- function()
 	{
 		local wasUpdating = this.m.IsUpdating;
 		this.m.IsUpdating = true;
@@ -27,7 +27,7 @@
 		foreach (s in this.m.Skills)
 		{
 			if (!s.isGarbage())
-				s.onActorInterrupted();
+				s.MV_onActorInterrupted();
 		}
 
 		this.m.IsUpdating = wasUpdating;
@@ -55,10 +55,10 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
-		q.m.MV_InterruptionFrame <- 0; // Part of the actor.interrupt framework
-		q.m.MV_InterruptionCount <- 0; // Part of the actor.interrupt framework
+		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interrupt framework
+		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interrupt framework
 
-		// Part of actor.interrupt framework
+		// Part of actor.MV_interrupt framework
 		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
 		// immediately one after the other i.e. it happens within a single frame. So we check if all 3 effects were
 		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
@@ -74,24 +74,24 @@
 				case "effects.spearwall":
 				case "effects.riposte":
 					local frame = ::Time.getFrame();
-					if (frame != this.m.MV_InterruptionFrame)
+					if (frame != this.m.__MV_InterruptionFrame)
 					{
-						this.m.MV_InterruptionCount = 0;
-						this.m.MV_InterruptionFrame = frame;
+						this.m.__MV_InterruptionCount = 0;
+						this.m.__MV_InterruptionFrame = frame;
 					}
 					else
 					{
-						this.m.MV_InterruptionCount++;
+						this.m.__MV_InterruptionCount++;
 					}
 					break;
 			}
 
 			__original(_skillID);
 
-			if (this.m.MV_InterruptionCount == 3)
+			if (this.m.__MV_InterruptionCount == 3)
 			{
-				this.m.MV_InterruptionCount = 0;
-				this.getActor().interrupt();
+				this.m.__MV_InterruptionCount = 0;
+				this.getActor().MV_interrupt();
 			}
 		}
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -92,7 +92,7 @@
 
 	// MV: Added
 	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function( _offensive, _defensive )
+	q.onActorInterrupted <- function()
 	{
 		local wasUpdating = this.m.IsUpdating;
 		this.m.IsUpdating = true;
@@ -100,7 +100,25 @@
 		foreach (s in this.m.Skills)
 		{
 			if (!s.isGarbage())
-				s.onActorInterrupted(_offensive, _defensive);
+				s.onActorInterrupted();
+		}
+
+		this.m.IsUpdating = wasUpdating;
+		this.update();
+	}
+
+	// MV: Added
+	// triggered from onAdded of disarmed_effect
+	// but modders can also manually call this from other places as necessary.
+	q.MV_onDisarmed <- function()
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+				s.MV_onDisarmed();
 		}
 
 		this.m.IsUpdating = wasUpdating;
@@ -119,8 +137,8 @@
 		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
 		// This is done instead of hooking every single vanilla file which triggers these kinds of interruptions.
 		// This implementation should also cover all mods which followed the vanilla style of removing those 3 effects only.
-		// An exception is the disarmed_effect which doesn't remove shieldwall. For that we hook that effect directly and do
-		// offensive interrupt only.
+		// An exception is the disarmed_effect which doesn't remove shieldwall. For that we trigger a new event MV_onDisarmed
+		// from disarmed_effect.onAdded directly.
 		q.removeByID = @(__original) function( _skillID )
 		{
 			switch (_skillID)
@@ -143,7 +161,7 @@
 
 			__original(_skillID);
 
-			if (this.m.MV_InterruptionCount >= 2)
+			if (this.m.MV_InterruptionCount == 3)
 			{
 				this.m.MV_InterruptionCount = 0;
 				this.getActor().interrupt();

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -129,7 +129,7 @@
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
 		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interruptSkills framework
-		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interruptSkills framework
+		q.m.__MV_InterruptedSkillIDs <- []; // Part of the actor.MV_interruptSkills framework
 
 		// Part of actor.MV_interruptSkills framework
 		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
@@ -149,21 +149,21 @@
 					local frame = ::Time.getFrame();
 					if (frame != this.m.__MV_InterruptionFrame)
 					{
-						this.m.__MV_InterruptionCount = 0;
+						this.m.__MV_InterruptedSkillIDs.clear();
 						this.m.__MV_InterruptionFrame = frame;
 					}
-					else
+					else if (this.m.__MV_InterruptedSkillIDs.find(_skillID) == null)
 					{
-						this.m.__MV_InterruptionCount++;
+						this.m.__MV_InterruptedSkillIDs.push(_skillID);
 					}
 					break;
 			}
 
 			__original(_skillID);
 
-			if (this.m.__MV_InterruptionCount == 3)
+			if (this.m.__MV_InterruptedSkillIDs.len() == 3)
 			{
-				this.m.__MV_InterruptionCount = 0;
+				this.m.__MV_InterruptedSkillIDs.clear();
 				this.getActor().MV_interruptSkills();
 			}
 		}

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -91,8 +91,8 @@
 	}}.MV_onMoraleStateChanged;
 
 	// MV: Added
-	// Part of the actor.MV_interrupt framework
-	q.MV_onActorInterrupted <- function()
+	// Part of the actor.MV_interruptSkills framework
+	q.MV_onSkillsInterrupted <- function()
 	{
 		local wasUpdating = this.m.IsUpdating;
 		this.m.IsUpdating = true;
@@ -100,7 +100,7 @@
 		foreach (s in this.m.Skills)
 		{
 			if (!s.isGarbage())
-				s.MV_onActorInterrupted();
+				s.MV_onSkillsInterrupted();
 		}
 
 		this.m.IsUpdating = wasUpdating;
@@ -128,10 +128,10 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
-		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interrupt framework
-		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interrupt framework
+		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interruptSkills framework
+		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interruptSkills framework
 
-		// Part of actor.MV_interrupt framework
+		// Part of actor.MV_interruptSkills framework
 		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
 		// immediately one after the other i.e. it happens within a single frame. So we check if all 3 effects were
 		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
@@ -164,7 +164,7 @@
 			if (this.m.__MV_InterruptionCount == 3)
 			{
 				this.m.__MV_InterruptionCount = 0;
-				this.getActor().MV_interrupt();
+				this.getActor().MV_interruptSkills();
 			}
 		}
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -91,8 +91,8 @@
 	}}.MV_onMoraleStateChanged;
 
 	// MV: Added
-	// Part of the actor.interrupt framework
-	q.onActorInterrupted <- function()
+	// Part of the actor.MV_interrupt framework
+	q.MV_onActorInterrupted <- function()
 	{
 		local wasUpdating = this.m.IsUpdating;
 		this.m.IsUpdating = true;
@@ -100,7 +100,7 @@
 		foreach (s in this.m.Skills)
 		{
 			if (!s.isGarbage())
-				s.onActorInterrupted();
+				s.MV_onActorInterrupted();
 		}
 
 		this.m.IsUpdating = wasUpdating;
@@ -128,10 +128,10 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
-		q.m.MV_InterruptionFrame <- 0; // Part of the actor.interrupt framework
-		q.m.MV_InterruptionCount <- 0; // Part of the actor.interrupt framework
+		q.m.__MV_InterruptionFrame <- 0; // Part of the actor.MV_interrupt framework
+		q.m.__MV_InterruptionCount <- 0; // Part of the actor.MV_interrupt framework
 
-		// Part of actor.interrupt framework
+		// Part of actor.MV_interrupt framework
 		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
 		// immediately one after the other i.e. it happens within a single frame. So we check if all 3 effects were
 		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
@@ -147,24 +147,24 @@
 				case "effects.spearwall":
 				case "effects.riposte":
 					local frame = ::Time.getFrame();
-					if (frame != this.m.MV_InterruptionFrame)
+					if (frame != this.m.__MV_InterruptionFrame)
 					{
-						this.m.MV_InterruptionCount = 0;
-						this.m.MV_InterruptionFrame = frame;
+						this.m.__MV_InterruptionCount = 0;
+						this.m.__MV_InterruptionFrame = frame;
 					}
 					else
 					{
-						this.m.MV_InterruptionCount++;
+						this.m.__MV_InterruptionCount++;
 					}
 					break;
 			}
 
 			__original(_skillID);
 
-			if (this.m.MV_InterruptionCount == 3)
+			if (this.m.__MV_InterruptionCount == 3)
 			{
-				this.m.MV_InterruptionCount = 0;
-				this.getActor().interrupt();
+				this.m.__MV_InterruptionCount = 0;
+				this.getActor().MV_interrupt();
 			}
 		}
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -1,3 +1,7 @@
+// MV: Added
+// Part of the actor.interrupt framework
+::MSU.Skills.addEvent("onActorInterrupted", function( _offensive, _defensive ) {});
+
 ::ModularVanilla.MH.hook("scripts/skills/skill_container", function(q) {
 	// MV: Added
 	// part of affordability preview system
@@ -93,6 +97,46 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
+		q.m.MV_InterruptionFrame <- 0; // Part of the actor.interrupt framework
+		q.m.MV_InterruptionCount <- 0; // Part of the actor.interrupt framework
+
+		// Part of actor.interrupt framework
+		// In vanilla skills which "interrupt" a character remove: effects.shieldwall, effects.spearwall, effects.riposte
+		// immediately one after the other i.e. it happens within a single frame. So we check if all 3 effects were
+		// removed in a single frame and assume that the vanilla intention is to trigger an interruption of the actor.
+		// This is done instead of hooking every single vanilla file which triggers these kinds of interruptions.
+		// This implementation should also cover all mods which followed the vanilla style of removing those 3 effects only.
+		// An exception is the disarmed_effect which doesn't remove shieldwall. For that we hook that effect directly and do
+		// offensive interrupt only.
+		q.removeByID = @(__original) function( _skillID )
+		{
+			switch (_skillID)
+			{
+				case "effects.shieldwall":
+				case "effects.spearwall":
+				case "effects.riposte":
+					local frame = ::Time.getFrame();
+					if (frame != this.m.MV_InterruptionFrame)
+					{
+						this.m.MV_InterruptionCount = 0;
+						this.m.MV_InterruptionFrame = frame;
+					}
+					else
+					{
+						this.m.MV_InterruptionCount++;
+					}
+					break;
+			}
+
+			__original(_skillID);
+
+			if (this.m.MV_InterruptionCount >= 2)
+			{
+				this.m.MV_InterruptionCount = 0;
+				this.getActor().interrupt();
+			}
+		}
+
 		// MV: Changed
 		// part of affordability preview system
 		// Prevent collectGarbage from running during a preview type skill_container.update

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -1,7 +1,3 @@
-// MV: Added
-// Part of the actor.interrupt framework
-::MSU.Skills.addEvent("onActorInterrupted", function( _offensive, _defensive ) {});
-
 ::ModularVanilla.MH.hook("scripts/skills/skill_container", function(q) {
 	// MV: Added
 	// part of affordability preview system
@@ -93,6 +89,23 @@
 
 		this.update();
 	}}.MV_onMoraleStateChanged;
+
+	// MV: Added
+	// Part of the actor.interrupt framework
+	q.onActorInterrupted <- function( _offensive, _defensive )
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+				s.onActorInterrupted(_offensive, _defensive);
+		}
+
+		this.m.IsUpdating = wasUpdating;
+		this.update();
+	}
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {

--- a/scripts/!mods_preload/mod_modular_vanilla.nut
+++ b/scripts/!mods_preload/mod_modular_vanilla.nut
@@ -77,6 +77,13 @@
 }, ::Hooks.QueueBucket.AfterHooks);
 
 ::ModularVanilla.MH.queue(function() {
+	foreach (fn in ::ModularVanilla.QueueBucket.VeryLate)
+	{
+		fn();
+	}
+}, ::Hooks.QueueBucket.VeryLate);
+
+::ModularVanilla.MH.queue(function() {
 	foreach (fn in ::ModularVanilla.QueueBucket.FirstWorldInit)
 	{
 		fn();

--- a/scripts/!mods_preload/mod_modular_vanilla.nut
+++ b/scripts/!mods_preload/mod_modular_vanilla.nut
@@ -80,6 +80,13 @@
 }, ::Hooks.QueueBucket.AfterHooks);
 
 ::ModularVanilla.MH.queue(function() {
+	foreach (fn in ::ModularVanilla.QueueBucket.VeryLate)
+	{
+		fn();
+	}
+}, ::Hooks.QueueBucket.VeryLate);
+
+::ModularVanilla.MH.queue(function() {
 	foreach (fn in ::ModularVanilla.QueueBucket.FirstWorldInit)
 	{
 		fn();


### PR DESCRIPTION
This is my implementation of a [feature request](https://github.com/MSUTeam/MSU/issues/327) that was originally made over at MSU. If we like this to be part of MSU we could move it there.

The implementation's meat is in the `skill_container` hook where we hook the `removeByID` function and detect a vanilla "interruption" of the actor. This means that all vanilla skills which interrupt actors are automatically covered, and even modded skills which follow the vanilla style of interruption will be covered.