### PR TITLE
feat: add ability to specify a base item for named items

### DIFF
--- a/mod_modular_vanilla/hooks/items/armor/named/named_armor.nut
+++ b/mod_modular_vanilla/hooks/items/armor/named/named_armor.nut
@@ -1,0 +1,16 @@
+::ModularVanilla.MH.hook("scripts/items/armor/named/named_armor", function(q) {
+	// MV: Part of framework: base item for named items
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			// The following fields are used in vanilla randomizeValues()
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			// -- No such fields for this particular named item type --
+		];
+	}
+});

--- a/mod_modular_vanilla/hooks/items/helmets/named/named_helmet.nut
+++ b/mod_modular_vanilla/hooks/items/helmets/named/named_helmet.nut
@@ -1,0 +1,18 @@
+::ModularVanilla.MH.hook("scripts/items/helmets/named/named_helmet", function(q) {
+	// MV: Part of framework: base item for named items
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			// The following fields are used in vanilla randomizeValues()
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			"Armor", // This field is actually redundant and is unused in vanilla
+			"ArmorMax", // This field is actually redundant and is unused in vanilla
+			"Vision",
+		];
+	}
+});

--- a/mod_modular_vanilla/hooks/items/item.nut
+++ b/mod_modular_vanilla/hooks/items/item.nut
@@ -1,0 +1,64 @@
+::ModularVanilla.MH.hook("scripts/items/item", function(q) {
+	// MV: Added part of framework: base item for named items
+	q.m.BaseItemScript <- null;
+
+	// MV: Added part of framework: base item for named items
+	q.getBaseItemFields <- function()
+	{
+		return [];
+	}
+
+	// MV: Added part of framework: base item for named items
+	q.setValuesBeforeRandomize <- function( _baseItem )
+	{
+		if (_baseItem != null)
+		{
+			foreach (field in this.getBaseItemFields())
+			{
+				this.m[field] = _baseItem.m[field];
+			}
+		}
+	}
+
+	// MV: Added part of framework: base item for named items
+	q.randomizeValues <- function()
+	{
+	}
+});
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hookTree("scripts/items/item", function(q) {
+		// MV: Part of framework: base item for named items
+		q.create = @(__original) function()
+		{
+			// Prevent the vanilla call to this.randomizeValues() within create() from randomizing anything
+			// because we want to set the values from the base item first.
+			local randomizeValues = this.randomizeValues;
+			this.randomizeValues = @() null;
+			__original();
+			this.randomizeValues = randomizeValues;
+
+			this.setValuesBeforeRandomize(this.m.BaseItemScript == null ? null : ::new(this.m.BaseItemScript));
+			this.randomizeValues();
+		}
+
+		// MV: Part of framework: base item for named items
+		q.setValuesBeforeRandomize = @(__original) function( _baseItem )
+		{
+			if (_baseItem == null)
+			{
+				__original(_baseItem);
+				return;
+			}
+
+			// The Named itemtype is lost when copying the ItemType from the base item
+			// so we add it back if this item already had it
+			local isNamedItem = this.isItemType(::Const.Items.ItemType.Named);
+			__original(_baseItem);
+			if (isNamedItem)
+			{
+				this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.Named;
+			}
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/items/shields/named/named_shield.nut
+++ b/mod_modular_vanilla/hooks/items/shields/named/named_shield.nut
@@ -1,0 +1,19 @@
+::ModularVanilla.MH.hook("scripts/items/shields/named/named_shield", function(q) {
+	// MV: Part of framework: base item for named items
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			// The following fields are used in vanilla randomizeValues()
+			"Condition",
+			"ConditionMax",
+			"MeleeDefense",
+			"RangedDefense",
+			"StaminaModifier",
+			"FatigueOnSkillUse"
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			// -- No such fields for this particular named item type --
+		];
+	}
+});

--- a/mod_modular_vanilla/hooks/items/weapons/named/named_weapon.nut
+++ b/mod_modular_vanilla/hooks/items/weapons/named/named_weapon.nut
@@ -1,0 +1,38 @@
+::ModularVanilla.MH.hook("scripts/items/weapons/named/named_weapon", function(q) {
+	// MV: Part of framework: base item for named items
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			// The following fields are used in vanilla randomizeValues()
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+			"RegularDamage",
+			"RegularDamageMax",
+			"ArmorDamageMult",
+			"ChanceToHitHead",
+			"DirectDamageMult",
+			"DirectDamageAdd",
+			"StaminaModifier",
+			"ShieldDamage",
+			"AdditionalAccuracy",
+			"FatigueOnSkillUse",
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			"Ammo",
+			"AmmoMax",
+			"AmmoCost",
+			"IsAoE",
+			"SlotType",
+			"BlockedSlotType",
+			"ItemType",
+			"WeaponType",
+			"IsDoubleGrippable",
+			"IsAgainstShields",
+			"RangeMin",
+			"RangeMax",
+			"RangeIdeal",
+		];
+	}
+});


### PR DESCRIPTION
Values of certain fields of the base item's m table are copied over to the named item before randomizing.

Note: this is a potential candidate for inclusion in MSU.