### PR TITLE
feat: add affordability preview

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -1,3 +1,50 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hookTree("scripts/entity/tactical/actor", function (q) {
+	// part of affordability preview system START
+		// MV: Changed
+		// We modify all these below functions to prevent them
+		// from setting the fields during the skill_container.update() function
+		// during a preview type update -- part of the affordability preview system
+		// Note: Done inside a hookTree because vanilla overwrites these functions for e.g. lindwurm_tail
+		q.setActionPoints = @(__original) function( _a )
+		{
+			if (!this.isPreviewing())
+				return __original(_a);
+		}
+
+		q.setFatigue = @(__original) function( _f )
+		{
+			if (!this.isPreviewing())
+				return __original(_f);
+		}
+
+		q.setHitpointsPct = @(__original) function( _h )
+		{
+			if (!this.isPreviewing())
+				return __original(_h);
+		}
+
+		q.onSkillsUpdated = @(__original) function()
+		{
+			if (!this.isPreviewing())
+				return __original();
+		}
+
+		q.updateOverlay = @(__original) function()
+		{
+			if (!this.isPreviewing())
+				return __original();
+		}
+
+		q.setDirty = @(__original) function( _value )
+		{
+			if (!this.isPreviewing())
+				return __original(_value);
+		}
+	// part of affordability preview system END
+	});
+});
+
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
 // part of affordability preview system START
 	// MV: Added
@@ -38,46 +85,6 @@
 	q.getCostsPreview <- function()
 	{
 		return this.m.MV_CostsPreview;
-	}
-
-	// MV: Changed
-	// We modify all these below functions to prevent them
-	// from setting the fields during the skill_container.update() function
-	// during a preview type update -- part of the affordability preview system
-	q.setActionPoints = @(__original) function( _a )
-	{
-		if (!this.isPreviewing())
-			return __original(_a);
-	}
-
-	q.setFatigue = @(__original) function( _f )
-	{
-		if (!this.isPreviewing())
-			return __original(_f);
-	}
-
-	q.setHitpointsPct = @(__original) function( _h )
-	{
-		if (!this.isPreviewing())
-			return __original(_h);
-	}
-
-	q.onSkillsUpdated = @(__original) function()
-	{
-		if (!this.isPreviewing())
-			return __original();
-	}
-
-	q.updateOverlay = @(__original) function()
-	{
-		if (!this.isPreviewing())
-			return __original();
-	}
-
-	q.setDirty = @(__original) function( _value )
-	{
-		if (!this.isPreviewing())
-			return __original(_value);
 	}
 // part of affordability preview system END
 

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -1,4 +1,86 @@
 ::ModularVanilla.MH.hook("scripts/entity/tactical/actor", function (q) {
+// part of affordability preview system START
+	// MV: Added
+	q.m.MV_IsPreviewing <- false;
+	q.m.MV_CostsPreview <- null;
+	q.m.MV_PreviewSkill <- null;
+	q.m.MV_PreviewMovement <- null;
+
+	// MV: Added
+	q.resetPreview <- function()
+	{
+		this.m.MV_IsPreviewing = false;
+		this.m.MV_CostsPreview = null;
+		this.m.MV_PreviewSkill = null;
+		this.m.MV_PreviewMovement = null;
+		this.getSkills().update();
+	}
+
+	// MV: Added
+	q.isPreviewing <- function()
+	{
+		return this.m.MV_IsPreviewing;
+	}
+
+	// MV: Added
+	q.getPreviewSkill <- function()
+	{
+		return this.m.MV_PreviewSkill;
+	}
+
+	// MV: Added
+	q.getPreviewMovement <- function()
+	{
+		return this.m.MV_PreviewMovement;
+	}
+
+	// MV: Added
+	q.getCostsPreview <- function()
+	{
+		return this.m.MV_CostsPreview;
+	}
+
+	// MV: Changed
+	// We modify all these below functions to prevent them
+	// from setting the fields during the skill_container.update() function
+	// during a preview type update -- part of the affordability preview system
+	q.setActionPoints = @(__original) function( _a )
+	{
+		if (!this.isPreviewing())
+			return __original(_a);
+	}
+
+	q.setFatigue = @(__original) function( _f )
+	{
+		if (!this.isPreviewing())
+			return __original(_f);
+	}
+
+	q.setHitpointsPct = @(__original) function( _h )
+	{
+		if (!this.isPreviewing())
+			return __original(_h);
+	}
+
+	q.onSkillsUpdated = @(__original) function()
+	{
+		if (!this.isPreviewing())
+			return __original();
+	}
+
+	q.updateOverlay = @(__original) function()
+	{
+		if (!this.isPreviewing())
+			return __original();
+	}
+
+	q.setDirty = @(__original) function( _value )
+	{
+		if (!this.isPreviewing())
+			return __original(_value);
+	}
+// part of affordability preview system END
+
 	// Extraction of part of vanilla logic from actor.onDamageReceived
 	q.calcArmorDamageReceived <- function( _skill, _hitInfo )
 	{

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -583,3 +583,42 @@
 		}
 	}
 });
+
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/skill", function(q) {
+		// MV: Changed
+		// part of affordability preview system
+		q.getCostString = @(__original) function()
+		{
+			if (!this.getContainer().getActor().isPreviewing() || ::getModSetting("mod_msu", "ExpandedSkillTooltips").getValue() == false)
+				return __original();
+
+			local actor = this.getContainer().getActor();
+			local previewFatigue = actor.getPreviewFatigue();
+			local previewAP = actor.getPreviewActionPoints();
+
+			this.getContainer().update();
+
+			// TODO: Hook the js side to work properly with animations of skills which aren't usable
+			// otherwise currently this isUsable thing doesn't work as intended
+			// i.e. preview_unusable skills don't show disabled icon when previewing
+			// local isUsablePreview = this.isUsable();
+
+			local ret = __original();
+
+			actor.m.MV_IsPreviewing = false;
+			this.getContainer().update();
+			actor.m.MV_IsPreviewing = true;
+
+			actor.setPreviewFatigue(previewFatigue);
+			actor.setPreviewActionPoints(previewAP);
+
+			// if (!isUsablePreview)
+			// {
+			// 	ret = ::MSU.String.replace(ret, "after ", "and will [color=" + ::Const.UI.Color.NegativeValue + "]not be usable[/color] after ");
+			// }
+			return ret;
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -1,0 +1,36 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
+		// MV: Changed
+		// part of affordability preview system
+		// Prevent collectGarbage from running during a preview type skill_container.update
+		q.collectGarbage = @(__original) function( _performUpdate = true )
+		{
+			if (!this.getActor().isPreviewing())
+				return __original(_performUpdate);
+		}
+
+		// MV: Changed
+		// part of affordability preview system
+		q.onTurnEnd = @(__original) function()
+		{
+			this.getActor().resetPreview();
+			return __original();
+		}
+
+		// MV: Changed
+		// part of affordability preview system
+		q.onWaitTurn = @(__original) function()
+		{
+			this.getActor().resetPreview();
+			return __original();
+		}
+
+		// MV: Changed
+		// part of affordability preview system
+		q.onCombatFinished = @(__original) function()
+		{
+			this.getActor().resetPreview();
+			return __original();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/states/tactical_state.nut
+++ b/mod_modular_vanilla/hooks/states/tactical_state.nut
@@ -1,0 +1,19 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/states/tactical_state", function(q) {
+		// MV: Changed
+		// part of affordability preview system
+		q.executeEntityTravel = @(__original) function( _activeEntity, _mouseEvent )
+		{
+			_activeEntity.resetPreview();
+			return __original(_activeEntity, _mouseEvent);
+		}
+
+		// MV: Changed
+		// part of affordability preview system
+		q.executeEntitySkill = @(__original) function( _activeEntity, _targetTile )
+		{
+			_activeEntity.resetPreview();
+			return __original(_activeEntity, _targetTile);
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -1,0 +1,84 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar", function(q) {
+		// MV: Changed
+		// part of affordability preview system
+		q.setActiveEntityCostsPreview = @() function( _costsPreview )
+		{
+			local activeEntity = this.getActiveEntity();
+			if (activeEntity == null || ::getModSetting("mod_msu", "ExpandedSkillTooltips").getValue() == false)
+				return;
+
+			if (this.m.ActiveEntityCostsPreview == null)
+				this.m.ActiveEntityCostsPreview = {};
+
+			this.m.ActiveEntityCostsPreview.id <- activeEntity.getID();
+
+			if (!("ActionPoints" in _costsPreview))
+				_costsPreview.ActionPoints <- 0;
+			if (!("Fatigue" in _costsPreview))
+				_costsPreview.Fatigue <- 0;
+
+			if ("SkillID" in _costsPreview)
+			{
+				activeEntity.m.MV_PreviewSkill = activeEntity.getSkills().getSkillByID(_costsPreview.SkillID);
+				activeEntity.setPreviewSkillID(_costsPreview.SkillID);
+			}
+			else
+			{
+				activeEntity.setPreviewSkillID("");
+				activeEntity.m.MV_PreviewMovement = ::Tactical.getNavigator().getCostForPath(activeEntity, ::Tactical.getNavigator().getLastSettings(), activeEntity.getActionPoints(), activeEntity.getFatigueMax() - activeEntity.getFatigue());
+			}
+
+			// Compatibility patch to run MSU affordability preview system because we overwrite this function completely
+			activeEntity.getSkills().m.IsPreviewing = true;
+			activeEntity.getSkills().onAffordablePreview(activeEntity.m.MV_PreviewSkill, activeEntity.m.MV_PreviewMovement == null ? null : activeEntity.m.MV_PreviewMovement.End);
+			// --
+
+			activeEntity.m.MV_CostsPreview = _costsPreview;
+			activeEntity.m.MV_IsPreviewing = true;
+			activeEntity.getSkills().update();
+
+			this.m.ActiveEntityCostsPreview.actionPointsPreview <- activeEntity.getActionPoints() - _costsPreview.ActionPoints;
+			if (this.m.ActiveEntityCostsPreview.actionPointsPreview < 0)
+			{
+				this.m.ActiveEntityCostsPreview.actionPointsPreview = activeEntity.getActionPoints();
+			}
+			this.m.ActiveEntityCostsPreview.actionPointsMaxPreview <- activeEntity.getActionPointsMax();
+
+			this.m.ActiveEntityCostsPreview.fatiguePreview <- activeEntity.getFatigue() + _costsPreview.Fatigue;
+			if (this.m.ActiveEntityCostsPreview.fatiguePreview > activeEntity.getFatigueMax())
+			{
+				this.m.ActiveEntityCostsPreview.fatiguePreview = activeEntity.getFatigueMax();
+			}
+			this.m.ActiveEntityCostsPreview.fatigueMaxPreview <- activeEntity.getFatigueMax();
+
+			activeEntity.setPreviewActionPoints(this.m.ActiveEntityCostsPreview.actionPointsPreview);
+			activeEntity.setPreviewFatigue(this.m.ActiveEntityCostsPreview.fatiguePreview);
+
+			this.m.JSHandle.asyncCall("updateCostsPreview", this.m.ActiveEntityCostsPreview);
+
+			activeEntity.m.MV_IsPreviewing = false;
+			activeEntity.getSkills().update();
+			activeEntity.m.MV_IsPreviewing = true;
+
+			// Have to set these again because the skill_container.update above sets these back to current action points
+			activeEntity.setPreviewActionPoints(this.m.ActiveEntityCostsPreview.actionPointsPreview);
+			activeEntity.setPreviewFatigue(this.m.ActiveEntityCostsPreview.fatiguePreview);
+		}
+
+		// MV: Changed
+		// part of affordability preview system
+		q.resetActiveEntityCostsPreview = @(__original) function()
+		{
+			local activeEntity = this.getActiveEntity();
+			if (activeEntity != null)
+			{
+				// Compatibility patch for MSU affordability preview system
+				activeEntity.getSkills().m.IsPreviewing = false;
+				// --
+				activeEntity.resetPreview();
+			}
+			__original();
+		}
+	});
+});

--- a/scripts/!mods_preload/mod_modular_vanilla.nut
+++ b/scripts/!mods_preload/mod_modular_vanilla.nut
@@ -36,6 +36,13 @@
 });
 
 ::ModularVanilla.MH.queue(function() {
+	foreach (fn in ::ModularVanilla.QueueBucket.VeryLate)
+	{
+		fn();
+	}
+}, ::Hooks.QueueBucket.VeryLate);
+
+::ModularVanilla.MH.queue(function() {
 	foreach (fn in ::ModularVanilla.QueueBucket.FirstWorldInit)
 	{
 		fn();


### PR DESCRIPTION
This includes a patch for the previously existing affordability preview system in MSU. This entire system is a candidate for inclusion in MSU once it is perfected at which point that compatibility patching will be handled by MSU itself. The implementation is based off of the approach [in this PR](https://github.com/MSUTeam/MSU/pull/354) over at MSU repo.