### PR TITLE
fix(vanilla): set armor penetration of shoot bolt to 50% like in vanilla

### DIFF
--- a/mod_modular_vanilla/hooks/skills/actives/shoot_bolt.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/shoot_bolt.nut
@@ -1,4 +1,14 @@
 ::ModularVanilla.MH.hook("scripts/skills/actives/shoot_bolt", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		// Vanilla Fix: shoot_bolt has a wrong penetration value, compared to what appears in the tooltip of the crossbows
+		if (this.m.DirectDamageMult == 0.45)	// If another mod fixes or changes this value, then we don't want to interfer
+		{
+			this.m.DirectDamageMult = 0.5;
+		}
+	}
+
 	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
 	q.onAfterUpdate = @() function( _properties )
 	{


### PR DESCRIPTION
This used to work correctly in Vanilla because they overwrote that value with 0.5 during the onAfterUpdate function, which is not the case anymore with Modular Vanilla

I tested this briefly ingame and verified that the armor penetration damage on the shoot bolt tooltip jumped up correctly after the fix.