### PR TITLE
fix(vanilla): goedendag having aoe tag

### DIFF
--- a/mod_modular_vanilla/hooks/items/weapons/goedendag.nut
+++ b/mod_modular_vanilla/hooks/items/weapons/goedendag.nut
@@ -1,0 +1,7 @@
+::ModularVanilla.MH.hook("scripts/items/weapons/goedendag", function(q) {
+	q.create = @(__original) function()
+	{
+		__original();
+		this.m.IsAoE = false;	// Vanilla Fix: Goedendag has no AoE effect but is still somehow marked as an AoE weapon
+	}
+});


### PR DESCRIPTION
In Vanilla this tag is only used for AI decisions
In Reforged this tag is also used to give NPCs different perks according to their equipped weapon