### PR TITLE
fix(vanilla): ArmorMult also multiplying the incoming armor damage

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -358,10 +358,10 @@
 		{
 			local overflowDamage = _hitInfo.DamageArmor;
 
-			if (this.getBaseProperties().Armor[_hitInfo.BodyPart] != 0)
+			if ((this.getBaseProperties().Armor[_hitInfo.BodyPart] * p.ArmorMult[_hitInfo.BodyPart]) != 0)
 			{
-				overflowDamage -= this.getBaseProperties().Armor[_hitInfo.BodyPart] * this.getBaseProperties().ArmorMult[_hitInfo.BodyPart];
-				this.getBaseProperties().Armor[_hitInfo.BodyPart] = this.Math.max(0, this.getBaseProperties().Armor[_hitInfo.BodyPart] * this.getBaseProperties().ArmorMult[_hitInfo.BodyPart] - _hitInfo.DamageArmor);
+				overflowDamage -= this.getBaseProperties().Armor[_hitInfo.BodyPart] * p.ArmorMult[_hitInfo.BodyPart];
+				this.getBaseProperties().Armor[_hitInfo.BodyPart] = this.Math.maxf(0, this.getBaseProperties().Armor[_hitInfo.BodyPart] - _hitInfo.DamageArmor / p.ArmorMult[_hitInfo.BodyPart]);
 				// vanilla lindwurm_tail says "natural armor is hit" here
 				this.Tactical.EventLog.logEx(this.Const.UI.getColorizedEntityName(this) + "\'s armor is hit for [b]" + this.Math.floor(_hitInfo.DamageArmor) + "[/b] damage");
 			}


### PR DESCRIPTION
Currently Normal Ifrits take 2x Armor Damage and Large Ifrits take 4x Armor Damage.
This is also the case in Vanilla.
This makes it so they currently all have only 110 effective Armor, no matter the size.

After that fix, larger Ifrits will be super-buffed, but that's for another mod to deal with

Two related Bug Reports:
https://steamcommunity.com/app/365360/discussions/1/4693406471885551423/
https://steamcommunity.com/app/365360/discussions/1/4365754575405178925/