### PR TITLE
feat: add virtual getQueryTargetValueMult AI functions for skills

### DIFF
--- a/mod_modular_vanilla/hooks/ai/tactical/behavior.nut
+++ b/mod_modular_vanilla/hooks/ai/tactical/behavior.nut
@@ -1,0 +1,10 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/ai/tactical/behavior", function(q) {
+		// MV: Changed
+		// Add skill_container events to allow skills to modify the queried value
+		q.queryTargetValue = @(__original) function( _entity, _target, _skill = null )
+		{
+			return __original(_entity, _target, _skill) * _entity.getSkills().getQueryTargetValueMult(_entity, _target, _skill) * _target.getSkills().getQueryTargetValueMult(_entity, _target, _skill);
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -578,6 +578,14 @@
 		}
 	}
 
+	// MV: Added
+	// Can be used to modify the result of behavior.queryTargetValue
+	// Must return the new value
+	q.getQueryTargetValueMult <- function( _entity, _target, _skill )
+	{
+		return 1.0;
+	}
+
 	q.onCostsPreview <- function( _costsPreview )
 	{
 	}

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -53,6 +53,26 @@
 			return __original();
 		}
 
+		// MV: Added
+		// called from behavior.queryTargetValue
+		q.getQueryTargetValueMult <- function( _entity, _target, _skill )
+		{
+			local ret = 1.0;
+
+			local wasUpdating = this.m.IsUpdating;
+			this.m.IsUpdating = true;
+			foreach (skill in this.m.Skills)
+			{
+				if (!skill.isGarbage())
+				{
+					ret *= skill.getQueryTargetValueMult(_entity, _target, _skill);
+				}
+			}
+			this.m.IsUpdating = wasUpdating;
+
+			return ret;
+		}
+
 		q.onCostsPreview <- function( _costsPreview )
 		{
 			local wasUpdating = this.m.IsUpdating;


### PR DESCRIPTION
Currently, if you want to teach the AI, what a certain skills likes/dislikes, you have to hard-code these preferences into the behaviors of the AI scripts using that skill (usually there is only a single AI script).

### Downsides
- The Skill is no longer well encapsuled within its script. Its behavior/code is split between different files, making it harder to assess what exactly it does, and to change/remove the skill.
- Hooking specific AI scripts is not very moddable. If a mod creates their own new AI scripts, then our skill behavior no longer works for those

## Proposal
These two events are powerful tools for modding to easily and honestly influence AI behaviors when designing skills of all kinds.
### Honesty
It is not the job of these events to manipulate enemies into doing purposefully doing the unoptimal thing to convey some sort of flavour. That should still be solely done via their agent scripts.
These events must be honest and truthful.
It's better to do small adjustments only with them instead of trying to enforce a "never do that"/"always do that" mentality.

### Examples:
- All Riposte-Like skills can discourage attackers slightly, if the skill they consider using can trigger a riposte
- Skills, which interrupt enemies, will value targets more highly if those have interruptable skills on them
- **Formidable Approach** can encourage the AI to disable it asap with a hit, if they are currently named in that perk
- Stunning Attacks under a "Poise System" can now predict how well the skill would stun the target and adjust the value accordingly to prevent those attacks being wasted or make sure that a susceptible poise-value is being abused accordingly