### PR TITLE
fix: named weapons sometimes displaying wrong weapon categories

### DIFF
--- a/mod_modular_vanilla/hooks/items/weapons/named/named_weapon.nut
+++ b/mod_modular_vanilla/hooks/items/weapons/named/named_weapon.nut
@@ -35,4 +35,13 @@
 			"RangeIdeal",
 		];
 	}
+
+	q.setValuesBeforeRandomize = @(__original) function( _baseItem )
+	{
+		// Part of what setValuesBeforeRandomize does is copying all weapon types over without adjusting the weapontype-string
+		// If a mod changes those weapon types during the create function, then those new type combination won't show up correctly
+		// We fix that by building categories manually for any named weapon after that transfer happened
+		__original(_baseItem);
+		this.buildCategoriesFromWeaponType();
+	}
 });


### PR DESCRIPTION
I verified this fix in one of my savegames under a mod, which adds the `Spear` weapon type to named Pikes.
After using this fix, the named pike correctly displays the new weapon type. Before it only shows polearm.

![image](https://github.com/user-attachments/assets/8051fddf-05de-455c-96c8-dd187ebd1353)

This is the second try for this PR. I accidentally merged it after being approved by Taro.
But since merging is now what we do, I force pushed the development branch again to revert that instantly.
Somehow the default for the PR button is set to "Merge pull request"