### PR TITLE
fix: lindwurm tail not applying acid correctly

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/enemies/lindwurm_tail.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/enemies/lindwurm_tail.nut
@@ -21,6 +21,11 @@
 	{
 		_hitInfo.BodyPart = ::Const.BodyPart.Body;
 
+		// This is explicitely done in the Vanilla implementation and it is needed to make Acid be applied correctly.
+		// The head is often too far (2+ tiles) away to apply acid with its own racial effect
+		// In Vanilla this call is more in the middle of the replicated onDamageReceived code. Not sure how much difference that makes
+		this.m.Racial.onDamageReceived(_attacker, _hitInfo.DamageInflictedHitpoints, _hitInfo.DamageInflictedArmor);
+
 		this.m.MV_IsDuringOnDamageReceived = true;
 		local ret = this.actor.onDamageReceived(_attacker, _skill, _hitInfo);
 		this.m.MV_IsDuringOnDamageReceived = false;


### PR DESCRIPTION
Vanilla also manually calls the `this.m.Racial` event. But that line of code went missing when normalizing the code in modular vanilla

I tested it ingame.
Before the fix, I would not get Acid, when I attack the Lindwurm tail. But attacking the head would apply acid as expected.
After the fix, the tail applies acid to me, like it is in vanilla