### PR TITLE
fix(vanilla): destination items isChangeableInBattle flag being ignored

### DIFF
--- a/mod_modular_vanilla/hooks/ui/screens/character/character_screen.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/character/character_screen.nut
@@ -1,0 +1,31 @@
+::ModularVanilla.MH.hook("scripts/ui/screens/character/character_screen", function(q) {
+	q.helper_isActionAllowed = @(__original) function( _entity, _items, _putIntoBags )
+	{
+		if (::MSU.Utils.hasState("tactical_state"))
+		{
+			// Vanilla Fix: Check all items for isChangeableInBattle, instead of just the source item
+			foreach (index, item in _items)
+			{
+				if (item != null && !item.isChangeableInBattle())
+				{
+					if (index == 0)	// This is always the source item as per vanilla standard
+					{
+						return {
+							error = "Source Item is not changable in battle.",	// We replace the less informative vanilla error "Item is not changable in battle." here
+							code = ::Const.CharacterScreen.ErrorCode.ItemIsNotChangableInBattle
+						};
+					}
+					else
+					{
+						return {
+							error = "Destination Item is not changable in battle.",
+							code = ::Const.CharacterScreen.ErrorCode.ItemIsNotChangableInBattle
+						};
+					}
+				}
+			}
+		}
+
+		return __original(_entity, _items, _putIntoBags);
+	}
+});

--- a/mod_modular_vanilla/hooks/ui/screens/character/character_screen.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/character/character_screen.nut
@@ -26,6 +26,9 @@
 			}
 		}
 
+		// Vanilla Fix: Allow items, that are not changable during battle to be put into bag slots outside of battle
+		_putIntoBags = false;
+
 		return __original(_entity, _items, _putIntoBags);
 	}
 });


### PR DESCRIPTION
There is the `IsChangeableInBattle` flag on items. When `false`, it i supposed to prevent those items from being swapped.
However in reality during a swap only the source item is checked for the presence of this flag, not the destination item.
In Vanilla this never causes issues, because Armor/Helmets are not allowed in the bag. And unleashable dogs (which are also forbidden to be swapped) are also not allowed in the bag (unlike some other accessories).

In Reforged this causes a bug with **Kingfisher**. If you net someone with that perk, your equipped net becomes locked, using `IsChangeableInBattle` flag. But you can still swap it out, by initiating the swap with a bag item.

## First Commit

The first Commit fixes that issues by checking both destination items, whether any of them is forbidden to be swapped, and then prevents the swapping.
However this does not provide the player with any feedback. They will just not be able to do that action.

## Second Commit

This one fixes a vanilla bug, where they check the `isChangeableInBattle` state outside of battle. That means, if a modder ever designs an item that is not changable in battle, but which may be stored into your bag. Then that item can't actually put in your bag, because of this `isChangeableInBattle` flag.

The fix is doing that in a very simple way by always setting the parameter `_putIntoBags` to `false`.
That might (big might) cause mod compatibility issues down the line. The information in that parameter is not lose though, since you have access to source and destination items, you can infer it