### PR TITLE
fix: missing World keys in AfterHooks automatic hireable bg array setup

### DIFF
--- a/mod_modular_vanilla/hooks/config/character_backgrounds.nut
+++ b/mod_modular_vanilla/hooks/config/character_backgrounds.nut
@@ -4,35 +4,66 @@
 ::Const.MV_HireableCharacterBackgrounds <- [];
 
 ::ModularVanilla.QueueBucket.AfterHooks.push(function() {
-	// This is required in the create function of settlements as that function calls getRandomName() which tries to access this.
-	// So we instantiate it temporarily.
+	// This is required in vanilla in the create function of settlements as that function calls
+	// getRandomName() which tries to access this. So we instantiate it temporarily.
 	::World.EntityManager <- ::new("scripts/entity/world/entity_manager");
+
+	// We instantiate all the other things which are usually instantiated in world_state.onInit
+	// as some settlements etc. (from mods) may try to access them during their create function.
+	::World.Factions <- ::new("scripts/factions/faction_manager");
+	::World.Combat <- ::new("scripts/entity/world/combat_manager");
+	::World.Contracts <- ::new("scripts/contracts/contract_manager");
+	::World.Events <- ::new("scripts/events/event_manager");
+	::World.Ambitions <- ::new("scripts/ambitions/ambition_manager");
+	::World.Retinue <- ::new("scripts/retinue/retinue_manager");
+	::World.Crafting <- ::new("scripts/crafting/crafting_manager");
+	::World.Statistics <- ::new("scripts/statistics/statistics_manager");
+	::World.Flags <- ::new("scripts/tools/tag_collection");
+	::World.Assets <- ::new("scripts/states/world/asset_manager");
 
 	foreach (script in ::IO.enumerateFiles("scripts/entity/world"))
 	{
-		local obj = ::new(script);
-		if (::isKindOf(obj, "settlement"))
+		try
 		{
-			::Const.MV_HireableCharacterBackgrounds.extend(obj.m.DraftList);
-		}
-		else if (::isKindOf(obj, "attached_location") || ::isKindOf(obj, "building") || ::isKindOf(obj, "situation"))
-		{
-			// Pass clone of list in case backgrounds are being removed, then only push bg from clone to original
-			// if it is a new kind of bg so we don't double the list on every iteration.
-			// Note: an alternative is to keep extending the original array, but it crashes (seems squirrel has a limit on array length)
-			// If we try to prevent this crash by extending with an array of uniques only, it is still significantly slower than this implementation
-			local clonedList = clone ::Const.MV_HireableCharacterBackgrounds;
-			obj.onUpdateDraftList(clonedList);
-			foreach (bg in clonedList)
+			local obj = ::new(script);
+			if (::isKindOf(obj, "settlement"))
 			{
-				if (::Const.MV_HireableCharacterBackgrounds.find(bg) == null)
+				::Const.MV_HireableCharacterBackgrounds.extend(obj.m.DraftList);
+			}
+			else if (::isKindOf(obj, "attached_location") || ::isKindOf(obj, "building") || ::isKindOf(obj, "situation"))
+			{
+				// Pass clone of list in case backgrounds are being removed, then only push bg from clone to original
+				// if it is a new kind of bg so we don't double the list on every iteration.
+				// Note: an alternative is to keep extending the original array, but it crashes (seems squirrel has a limit on array length)
+				// If we try to prevent this crash by extending with an array of uniques only, it is still significantly slower than this implementation
+				local clonedList = clone ::Const.MV_HireableCharacterBackgrounds;
+				obj.onUpdateDraftList(clonedList);
+				foreach (bg in clonedList)
 				{
-					::Const.MV_HireableCharacterBackgrounds.push(bg);
+					if (::Const.MV_HireableCharacterBackgrounds.find(bg) == null)
+					{
+						::Const.MV_HireableCharacterBackgrounds.push(bg);
+					}
 				}
 			}
+		}
+		catch (error)
+		{
+			::ModularVanilla.Debug.printError("Could not instantiate to get hireable backgrounds from " + script + ". Error: " + error);
 		}
 	}
 
 	delete ::World.EntityManager;
+	delete ::World.Factions;
+	delete ::World.Combat;
+	delete ::World.Contracts;
+	delete ::World.Events;
+	delete ::World.Ambitions;
+	delete ::World.Retinue;
+	delete ::World.Crafting;
+	delete ::World.Statistics;
+	delete ::World.Flags;
+	delete ::World.Assets;
+
 	::Const.MV_HireableCharacterBackgrounds = ::MSU.Array.uniques(::Const.MV_HireableCharacterBackgrounds);
 });

--- a/mod_modular_vanilla/hooks/config/character_backgrounds.nut
+++ b/mod_modular_vanilla/hooks/config/character_backgrounds.nut
@@ -23,33 +23,26 @@
 
 	foreach (script in ::IO.enumerateFiles("scripts/entity/world"))
 	{
-		try
+		local obj = ::new(script);
+		if (::isKindOf(obj, "settlement"))
 		{
-			local obj = ::new(script);
-			if (::isKindOf(obj, "settlement"))
+			::Const.MV_HireableCharacterBackgrounds.extend(obj.m.DraftList);
+		}
+		else if (::isKindOf(obj, "attached_location") || ::isKindOf(obj, "building") || ::isKindOf(obj, "situation"))
+		{
+			// Pass clone of list in case backgrounds are being removed, then only push bg from clone to original
+			// if it is a new kind of bg so we don't double the list on every iteration.
+			// Note: an alternative is to keep extending the original array, but it crashes (seems squirrel has a limit on array length)
+			// If we try to prevent this crash by extending with an array of uniques only, it is still significantly slower than this implementation
+			local clonedList = clone ::Const.MV_HireableCharacterBackgrounds;
+			obj.onUpdateDraftList(clonedList);
+			foreach (bg in clonedList)
 			{
-				::Const.MV_HireableCharacterBackgrounds.extend(obj.m.DraftList);
-			}
-			else if (::isKindOf(obj, "attached_location") || ::isKindOf(obj, "building") || ::isKindOf(obj, "situation"))
-			{
-				// Pass clone of list in case backgrounds are being removed, then only push bg from clone to original
-				// if it is a new kind of bg so we don't double the list on every iteration.
-				// Note: an alternative is to keep extending the original array, but it crashes (seems squirrel has a limit on array length)
-				// If we try to prevent this crash by extending with an array of uniques only, it is still significantly slower than this implementation
-				local clonedList = clone ::Const.MV_HireableCharacterBackgrounds;
-				obj.onUpdateDraftList(clonedList);
-				foreach (bg in clonedList)
+				if (::Const.MV_HireableCharacterBackgrounds.find(bg) == null)
 				{
-					if (::Const.MV_HireableCharacterBackgrounds.find(bg) == null)
-					{
-						::Const.MV_HireableCharacterBackgrounds.push(bg);
-					}
+					::Const.MV_HireableCharacterBackgrounds.push(bg);
 				}
 			}
-		}
-		catch (error)
-		{
-			::ModularVanilla.Debug.printError("Could not instantiate to get hireable backgrounds from " + script + ". Error: " + error);
 		}
 	}
 


### PR DESCRIPTION
We temporarily instantiate and populate all the keys in ::World that are created by vanilla in world_state.onInit. Furthermore, we wrap the instantiation in a try/catch block as a last resort to avoid errors.

EDIT: removed the try/catch block because it doesn't accomplish anything as the error happens within `create` function called by `::new` and the try/catch doesn't catch it.