### PR TITLE
fix(vanilla): certain skills using current instead of use properties

### DIFF
--- a/mod_modular_vanilla/hooks/skills/actives/crush_armor.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/crush_armor.nut
@@ -7,4 +7,7 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}
+
+	// VanillaFix: see documentation of helper function
+	::ModularVanilla.HooksHelper.fixGetTooltipProperties(q);
 });

--- a/mod_modular_vanilla/hooks/skills/actives/decapitate.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/decapitate.nut
@@ -14,4 +14,7 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}
+
+	// VanillaFix: see documentation of helper function
+	::ModularVanilla.HooksHelper.fixGetTooltipProperties(q);
 });

--- a/mod_modular_vanilla/hooks/skills/actives/demolish_armor_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/demolish_armor_skill.nut
@@ -7,4 +7,7 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}
+
+	// VanillaFix: see documentation of helper function
+	::ModularVanilla.HooksHelper.fixGetTooltipProperties(q);
 });

--- a/mod_modular_vanilla/hooks_helper.nut
+++ b/mod_modular_vanilla/hooks_helper.nut
@@ -1,0 +1,3 @@
+::ModularVanilla.HooksHelper <- {
+
+};

--- a/mod_modular_vanilla/hooks_helper.nut
+++ b/mod_modular_vanilla/hooks_helper.nut
@@ -1,3 +1,34 @@
 ::ModularVanilla.HooksHelper <- {
+	// VanillaFix: vanilla manually calculates the damage range for this tooltip using CurrentProperties
+	// whereas it should be using buildPropertiesForUse because otherwise it misses the damage buffs
+	// which are applied during onAnySkillUsed from perks etc. Relevant for vanilla skills such as decapitate.
+	function fixGetTooltipProperties(q)
+	{
+		q.getTooltip = @(__original) function()
+		{
+			local actor = this.getContainer().getActor();
+			if (actor instanceof ::WeakTableRef)
+			{
+				actor = actor.get();
+			}
 
+			// Vanilla calls getCurrentProperties at the start of the __original function, so we switcheroo it
+			// so that the first call to it returns the buildPropertiesForUse instead.
+			local actor_getCurrentProperties = actor.getCurrentProperties;
+			local skill = this;
+			actor.getCurrentProperties = function()
+			{
+				this.getCurrentProperties = actor_getCurrentProperties;
+				return this.getSkills().buildPropertiesForUse(skill, null);
+			}
+
+			local ret = __original();
+
+			// Even though the switcheroo should've been reverted in the switcherooed function above, we manually
+			// revert it just in case someone changed __original to never call getCurrentProperties.
+			actor.getCurrentProperties = actor_getCurrentProperties;
+
+			return ret;
+		}
+	}
 };

--- a/scripts/!mods_preload/mod_modular_vanilla.nut
+++ b/scripts/!mods_preload/mod_modular_vanilla.nut
@@ -26,6 +26,8 @@
 
 ::ModularVanilla.MH.queue("<mod_msu", function()
 {
+	::include("mod_modular_vanilla/hooks_helper.nut");
+
 	foreach (file in ::IO.enumerateFiles("mod_modular_vanilla/config"))
 	{
 		::include(file);
@@ -64,4 +66,5 @@
 		fn();
 	}
 	delete ::ModularVanilla.QueueBucket;
+	delete ::ModularVanilla.HooksHelper;
 }, ::Hooks.QueueBucket.FirstWorldInit);


### PR DESCRIPTION
In vanilla this causes these skills to show in their tooltip the damage range based on CurrentProperties instead of buildPropertiesForUse resulting in any damage modification applied during `onAnySkillUsed` to not be properly reflected in the tooltip.