### PR TITLE
feat: modularize player_party.updateStrength

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -1,0 +1,9 @@
+::ModularVanilla.MH.hook("scripts/entity/tactical/player", function (q) {
+	// MV: Extracted
+	// part of player_party.updateStrength modularization
+	q.MV_getStrength <- function()
+	{
+		// Same as vanilla in player_party.updateStrength except the addition of the skill_container event
+		return 10 + (this.getLevel() + 1) * 2.0;
+	}
+});

--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -3,7 +3,7 @@
 	// part of player_party.updateStrength modularization
 	q.MV_getStrength <- function()
 	{
-		// Same as vanilla in player_party.updateStrength except the addition of the skill_container event
+		// Same as vanilla in player_party.updateStrength
 		return 10 + (this.getLevel() + 1) * 2.0;
 	}
 });

--- a/mod_modular_vanilla/hooks/entity/world/player_party.nut
+++ b/mod_modular_vanilla/hooks/entity/world/player_party.nut
@@ -1,0 +1,36 @@
+::ModularVanilla.MH.hook("scripts/entity/world/player_party", function (q) {
+	// MV: Modularized
+	q.updateStrength = @() function()
+	{
+		this.m.Strength = 0.0;
+		local roster = ::World.getPlayerRoster().getAll();
+
+		if (roster.len() > ::World.Assets.getBrothersScaleMax())
+		{
+			roster.sort(this.onLevelCompare);
+		}
+
+		if (roster.len() < ::World.Assets.getBrothersScaleMin())
+		{
+			this.m.Strength += 10.0 * (::World.Assets.getBrothersScaleMin() - roster.len());
+		}
+
+		foreach (i, bro in roster)
+		{
+			if (i >= ::World.Assets.getBrothersScaleMax())
+			{
+				break;
+			}
+
+			// Extracted the logic of adding each bro's contribution to the strength
+			// and added call to new skill_container event for getting strength mult
+			this.m.Strength += bro.MV_getStrength() * bro.getSkills().MV_getPlayerPartyStrengthMult();
+		}
+
+		// Added call to new starting_scenario event for getting strength mult
+		if (!::MSU.isNull(::World.Assets.getOrigin()))
+		{
+			this.m.Strength *= ::World.Assets.getOrigin().MV_getPlayerPartyStrengthMult();
+		}
+	}
+});

--- a/mod_modular_vanilla/hooks/scenarios/world/starting_scenario.nut
+++ b/mod_modular_vanilla/hooks/scenarios/world/starting_scenario.nut
@@ -9,6 +9,7 @@
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hookTree("scripts/scenarios/world/starting_scenario", function (q) {
+		// MV: Changed
 		// part of player_party.updateStrength modularization
 		// During loading a save game, the player_party.updateStrength is called before the origin
 		// is instantiated, therefore the multiplier from the origin doesn't apply. So, we manually

--- a/mod_modular_vanilla/hooks/scenarios/world/starting_scenario.nut
+++ b/mod_modular_vanilla/hooks/scenarios/world/starting_scenario.nut
@@ -1,0 +1,22 @@
+::ModularVanilla.MH.hook("scripts/scenarios/world/starting_scenario", function (q) {
+	// MV: Added
+	// part of player_party.updateStrength modularization
+	q.MV_getPlayerPartyStrengthMult <- function()
+	{
+		return 1.0;
+	}
+});
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hookTree("scripts/scenarios/world/starting_scenario", function (q) {
+		// part of player_party.updateStrength modularization
+		// During loading a save game, the player_party.updateStrength is called before the origin
+		// is instantiated, therefore the multiplier from the origin doesn't apply. So, we manually
+		// trigger player_party.updateStrength once again after the origin's onInit.
+		q.onInit = @(__original) function()
+		{
+			__original();
+			::World.State.getPlayer().updateStrength();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -1,4 +1,11 @@
 ::ModularVanilla.MH.hook("scripts/skills/skill", function (q) {
+	// MV: Added
+	// part of player_party.updateStrength modularization
+	q.MV_getPlayerPartyStrengthMult <- function()
+	{
+		return 1.0;
+	}
+
 	q.getDamageRegular <- function( _properties, _targetEntity = null )
 	{
 		local damage = ::Math.rand(_properties.DamageRegularMin, _properties.DamageRegularMax) * _properties.DamageRegularMult;

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -1,3 +1,23 @@
+::ModularVanilla.MH.hook("scripts/skills/skill_container", function(q) {
+	// MV: Added
+	// part of player_party.updateStrength modularization
+	q.MV_getPlayerPartyStrengthMult <- function()
+	{
+		local ret = 1.0;
+
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+				ret *= s.MV_getPlayerPartyStrengthMult();
+		}
+		this.m.IsUpdating = wasUpdating;
+
+		return ret;
+	}
+});
+
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/skills/skill_container", function (q) {
 		// MV: Changed


### PR DESCRIPTION
- Extracted the logic of each bro's contribution to player party strength in `player_party.updateStrength` into a new `player.MV_getStrength()` function.
- Added `MV_getPlayerPartyStrengthMult()` event for origins and skills.