### PR TITLE
feat: add MV_onUpdateAIAgent event for skills and auto reset properties

### DIFF
--- a/mod_modular_vanilla/hooks/ai/tactical/agent.nut
+++ b/mod_modular_vanilla/hooks/ai/tactical/agent.nut
@@ -1,0 +1,26 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/ai/tactical/agent", function(q) {
+		// MV: Added
+		// part of MV_onUpdateAIAgent skill_container event
+		q.m.MV_OriginalProperties <- null;
+	});
+
+	::ModularVanilla.MH.hookTree("scripts/ai/tactical/agent", function(q) {
+		q.setActor = @(__original) function( _a )
+		{
+			__original(_a);
+			// MV: Added
+			// part of MV_onUpdateAIAgent skill_container event
+			this.m.MV_OriginalProperties = ::MSU.deepClone(this.getProperties());
+		}
+
+		q.onUpdate = @(__original) function()
+		{
+			// MV: Added
+			// part of MV_onUpdateAIAgent skill_container event
+			this.m.Properties = ::MSU.deepClone(this.m.MV_OriginalProperties);
+			this.getActor().getSkills().MV_onUpdateAIAgent();
+			__original();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/ai/tactical/agent.nut
+++ b/mod_modular_vanilla/hooks/ai/tactical/agent.nut
@@ -19,8 +19,8 @@
 			// MV: Added
 			// part of MV_onUpdateAIAgent skill_container event
 			this.m.Properties = ::MSU.deepClone(this.m.MV_OriginalProperties);
-			this.getActor().getSkills().MV_onUpdateAIAgent();
 			__original();
+			this.getActor().getSkills().MV_onUpdateAIAgent();
 		}
 	});
 });

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -586,6 +586,12 @@
 		return 1.0;
 	}
 
+	// MV: Added
+	// part of MV_onUpdateAIAgent skill_container event
+	q.MV_onUpdateAIAgent <- function()
+	{
+	}
+
 	q.onCostsPreview <- function( _costsPreview )
 	{
 	}

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -16,6 +16,20 @@
 
 		return ret;
 	}
+
+	// MV: Added
+	// part of MV_onUpdateAIAgent skill_container event
+	q.MV_onUpdateAIAgent <- function()
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+				s.MV_onUpdateAIAgent();
+		}
+		this.m.IsUpdating = wasUpdating;
+	}
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {


### PR DESCRIPTION
- Auto-reset agent properties to their starting values before every onUpdate so that they can be incrementally modified in the update functions.
- Add MV_onUpdateAIAgent event for skills to allow them to modify agent properties e.g. behavior score mult or other multipliers.