### PR TITLE
fix: change hook for queryTargetValue to hookTree

### DIFF
--- a/mod_modular_vanilla/hooks/ai/tactical/behavior.nut
+++ b/mod_modular_vanilla/hooks/ai/tactical/behavior.nut
@@ -1,5 +1,5 @@
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
-	::ModularVanilla.MH.hook("scripts/ai/tactical/behavior", function(q) {
+	::ModularVanilla.MH.hookTree("scripts/ai/tactical/behavior", function(q) {
 		// MV: Changed
 		// Add skill_container events to allow skills to modify the queried value
 		q.queryTargetValue = @(__original) function( _entity, _target, _skill = null )


### PR DESCRIPTION
Because certain behaviors can overwrite this function and we want to apply the multiplier to the value received at the end.