### PR TITLE
Refactor improve combat log

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -407,6 +407,7 @@
 		if (this.getHitpoints() <= 0)
 		{
 			this.spawnBloodDecals(this.getTile());
+			::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage)));
 			this.kill(_attacker, _skill, fatalityType);
 		}
 		else

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -330,6 +330,7 @@
 			}
 		}
 
+		local oldHitpoints = this.getHitpoints();	// We save the old hitpoints so that we can display them later in the combat log
 		if (damage > 0)
 		{
 			if (!this.m.IsAbleToDie && damage >= this.getHitpoints())
@@ -407,7 +408,7 @@
 		if (this.getHitpoints() <= 0)
 		{
 			this.spawnBloodDecals(this.getTile());
-			::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage)));
+			::Tactical.EventLog.logEx(format("%s\'s %s (%i) is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], oldHitpoints, ::Math.floor(damage)));
 			this.kill(_attacker, _skill, fatalityType);
 		}
 		else
@@ -444,20 +445,20 @@
 				{
 					if (damage > 0 && !this.isHiddenToPlayer())
 					{
-						::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage)));
+						::Tactical.EventLog.logEx(format("%s\'s %s (%i) is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], oldHitpoints, ::Math.floor(damage)));
 					}
 				}
 				else
 				{
 					if (this.isPlayerControlled() || !this.isHiddenToPlayer())
 					{
-						::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage and suffers %s", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage), injury.getNameOnly()));
+						::Tactical.EventLog.logEx(format("%s\'s %s (%i) is hit for %i damage and suffers %s", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], oldHitpoints, ::Math.floor(damage), injury.getNameOnly()));
 					}
 				}
 			}
 			else if (damage > 0 && !this.isHiddenToPlayer())
 			{
-				::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage)));
+				::Tactical.EventLog.logEx(format("%s\'s %s (%i) is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], oldHitpoints, ::Math.floor(damage)));
 			}
 
 			// MV: Extracted

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -444,20 +444,20 @@
 				{
 					if (damage > 0 && !this.isHiddenToPlayer())
 					{
-						this.Tactical.EventLog.logEx(this.Const.UI.getColorizedEntityName(this) + "\'s " + this.Const.Strings.BodyPartName[_hitInfo.BodyPart] + " is hit for [b]" + this.Math.floor(damage) + "[/b] damage");
+						::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage)));
 					}
 				}
 				else
 				{
 					if (this.isPlayerControlled() || !this.isHiddenToPlayer())
 					{
-						this.Tactical.EventLog.logEx(this.Const.UI.getColorizedEntityName(this) + "\'s " + this.Const.Strings.BodyPartName[_hitInfo.BodyPart] + " is hit for [b]" + this.Math.floor(damage) + "[/b] damage and suffers " + injury.getNameOnly() + "!");
+						::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage and suffers %s", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage), injury.getNameOnly()));
 					}
 				}
 			}
 			else if (damage > 0 && !this.isHiddenToPlayer())
 			{
-				this.Tactical.EventLog.logEx(this.Const.UI.getColorizedEntityName(this) + "\'s " + this.Const.Strings.BodyPartName[_hitInfo.BodyPart] + " is hit for [b]" + this.Math.floor(damage) + "[/b] damage");
+				::Tactical.EventLog.logEx(format("%s\'s %s is hit for %i damage", ::Const.UI.getColorizedEntityName(this), ::Const.Strings.BodyPartName[_hitInfo.BodyPart], ::Math.floor(damage)));
 			}
 
 			// MV: Extracted


### PR DESCRIPTION
Currently you dont see your hitpoint damage numbers when you kill an enemy.
The first commit changes that.

Currently you dont see the hitpoints that the target had before you attacked them. That is especially important in bigger hectic battles, when had to time to check the hitpoints beforehand, and when you want to make sure how close you were to surviving a certain hit.
The third commit changes that.