### PR TITLE
feat: extract calculation of maxTraits into new func in setStartValuesEx

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -54,7 +54,7 @@
 			];
 
 			// MV: Changed
-			// Vanilla iterates only 10 times and tries to add random traits from ::Const.CharacterTraits
+			// VanillaFix: Vanilla iterates only 10 times and tries to add random traits from ::Const.CharacterTraits
 			// and keeps rolling random traits until it finds one that returns false for isExcluded. This can
 			// sometimes lead to fewer traits than desired. So we change this logic completely.
 			local potential = ::Const.CharacterTraits.filter(@(_, _entry) !traits[0].isExcluded(_entry[0]));

--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -57,17 +57,18 @@
 			// VanillaFix: Vanilla iterates only 10 times and tries to add random traits from ::Const.CharacterTraits
 			// and keeps rolling random traits until it finds one that returns false for isExcluded. This can
 			// sometimes lead to fewer traits than desired. So we change this logic completely.
-			local potential = ::Const.CharacterTraits.filter(@(_, _entry) !traits[0].isExcluded(_entry[0]));
-			local maxTraits = this.MV_getMaxTraits();
+			local trait = traits[0];
+			local potential = ::Const.CharacterTraits;
 
 			for (local i = 0; i < maxTraits; i++)
 			{
+				potential = potential.filter(@(_, _entry) !trait.isExcluded(_entry[0]));
+
 				if (potential.len() == 0)
 					break;
 
-				local trait = ::new(::MSU.Array.rand(potential)[1]);
+				trait = ::new(::MSU.Array.rand(potential)[1]);
 				traits.push(trait);
-				potential = potential.filter(@(_, _entry) !trait.isExcluded(_entry[0]));
 			}
 
 			for (local i = 1; i < traits.len(); i++)

--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -14,4 +14,90 @@
 	{
 		return this.MV_getStrengthRaw() * this.getSkills().MV_getPlayerPartyStrengthMult();
 	}
+
+	// MV: Added
+	// Part of modularization of player.setStartValuesEx
+	q.MV_getMaxStartingTraits <- function()
+	{
+		return this.Math.rand(this.Math.rand(0, 1) == 0 ? 0 : 1, 2);
+	}
+
+	// MV: Modularized
+	// Copy of the vanilla function with the following changes:
+	// Extracted the calculation of max traits to add
+	q.setStartValuesEx = @() function( _backgrounds, _addTraits = true )
+	{
+		if (::isSomethingToSee() && ::World.getTime().Days >= 7)
+		{
+			_backgrounds = this.Const.CharacterPiracyBackgrounds;
+		}
+
+		local background = ::new("scripts/skills/backgrounds/" + _backgrounds[this.Math.rand(0, _backgrounds.len() - 1)]);
+		this.m.Skills.add(background);
+		this.m.Background = background;
+		this.m.Ethnicity = this.m.Background.getEthnicity();
+		background.buildAttributes();
+		background.buildDescription();
+
+		if (this.m.Name.len() == 0)
+		{
+			this.m.Name = background.m.Names[this.Math.rand(0, background.m.Names.len() - 1)];
+		}
+
+		if (_addTraits)
+		{
+			// MV: Extracted calculation of maxTraits into a new function
+			local maxTraits = this.MV_getMaxTraits();
+			local traits = [
+				background
+			];
+
+			for( local i = 0; i < maxTraits; i = ++i )
+			{
+				for( local j = 0; j < 10; j = ++j )
+				{
+					local trait = this.Const.CharacterTraits[this.Math.rand(0, this.Const.CharacterTraits.len() - 1)];
+					local nextTrait = false;
+
+					for( local k = 0; k < traits.len(); k = ++k )
+					{
+						if (traits[k].getID() == trait[0] || traits[k].isExcluded(trait[0]))
+						{
+							nextTrait = true;
+							break;
+						}
+					}
+
+					if (!nextTrait)
+					{
+						traits.push(this.new(trait[1]));
+						break;
+					}
+				}
+			}
+
+			for( local i = 1; i < traits.len(); i = ++i )
+			{
+				this.m.Skills.add(traits[i]);
+
+				if (traits[i].getContainer() != null)
+				{
+					traits[i].addTitle();
+				}
+			}
+		}
+
+		background.addEquipment();
+		background.setAppearance();
+		background.buildDescription(true);
+		this.m.Skills.update();
+		local p = this.m.CurrentProperties;
+		this.m.Hitpoints = p.Hitpoints;
+
+		if (_addTraits)
+		{
+			this.fillTalentValues();
+			this.fillAttributeLevelUpValues(this.Const.XP.MaxLevelWithPerkpoints - 1);
+		}
+	}
 });


### PR DESCRIPTION
The only way to modify number of traits currently is to overwrite this vanilla function completely which is bad for mod compatibility. We extract the most common thing people want to change i.e. number of traits.