### PR TITLE
fix(vanilla): armor damage log being printed even when armor damage is 0

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -358,7 +358,7 @@
 		}
 
 		// TODO: Extract into a separate function?
-		if (_hitInfo.DamageDirect < 1.0)
+		if (_hitInfo.DamageDirect < 1.0 && _hitInfo.DamageArmor > 0)	// Vanilla only checks for _hitInfo.DamageDirect here but DamageArmor might be set to 0 during some skills onBeforeDamageReceived event
 		{
 			local overflowDamage = _hitInfo.DamageArmor;
 


### PR DESCRIPTION
This never causes issues in vanilla, because no skill there adjusts the damage received this late.
And all skills which deal hitpoint damage but leave the armor untouched have a penetration of 1.0. So no log is printed there

I tested this ingame with a skill which sets the damage received to 0 in the `onBeforeDamageReceived` event.
Before this fix there was a log printed saying "Armor took 0 damage".
After this fix that log is no longer printed