### PR TITLE
feat: add character property to control hitchance min and max

### DIFF
--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -10,3 +10,8 @@
 	MV_DiversionHitChanceAdd = -15,
 	MV_DiversionDamageMult = 0.75
 });
+
+::MSU.Table.merge(::Const.CharacterProperties, {
+	MV_HitChanceMin = ::Const.Combat.MV_HitChanceMin,
+	MV_HitChanceMax = ::Const.Combat.MV_HitChanceMax
+});

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -201,7 +201,9 @@
 			toHit = ::Math.floor(toHit * (1.0 - this.MV_getDiversionChance(_targetEntity, _propertiesForUse, _propertiesForDefense)));
 		}
 
-		return this.Math.max(::Const.Combat.MV_HitChanceMin, this.Math.min(::Const.Combat.MV_HitChanceMax, toHit));
+		local hitChanceMin = ::Math.max(0, ::Math.min(_propertiesForUse.MV_HitChanceMin, _propertiesForDefense.MV_HitChanceMin));
+		local hitChanceMax = ::Math.min(100, ::Math.max(_propertiesForUse.MV_HitChanceMax, _propertiesForDefense.MV_HitChanceMax));
+		return ::Math.max(hitChanceMin, ::Math.min(hitChanceMax, toHit));
 	}
 
 	// MV: Changed


### PR DESCRIPTION
Provides a simple way for skills to have variable min/max hitchance. Example use-case:

```squirrel
// A status effect which having at least 5 stacks sets the maximum hit chance to 100.
function onAnySkillUsed( _skill, _targetEntity, _properties )
{
	if (this.m.Stacks >= 5)
	{
		_properties.MV_HitChanceMax = 100;
	}
}
```