### PR TITLE
Fix and modularize skill get expected damage

### DIFF
--- a/mod_modular_vanilla/hooks/config/tactical.nut
+++ b/mod_modular_vanilla/hooks/config/tactical.nut
@@ -21,7 +21,57 @@
 	// do not get it passed directly.
 	// Note: We populate it during actor.onDamageReceived only. However, during regular skill attack
 	// HitInfo is also first passed to onBeforeTargetHit (in skill.onScheduledTargetHit).
-	MV_CurrentHitInfo = null
+	MV_CurrentHitInfo = null,
+
+	// MV: Added
+	// Part of skill.onScheduledTargetHit modularization
+	// Similar to the vanilla instantiation and calculation of HitInfo in onScheduledTargetHit,
+	// this is meant to return the HitInfo from the perspective of the attacker i.e. outgoing damage.
+	// We use our MV functions to calculate damage to keep things DRY.
+		// _propertiesForUse and _propertiesForDefense parameters are just there so that when called from
+		//  onScheduledTargetHit we don't have to calculate the properties again.
+	function MV_initHitInfo( _skill, _targetEntity, _propertiesForUse = null, _propertiesForDefense = null )
+	{
+		if (_propertiesForUse == null)
+			_propertiesForUse = _skill.getContainer().buildPropertiesForUse(_skill, _targetEntity);
+		if (_propertiesForDefense == null && _targetEntity != null)
+			_propertiesForDefense = _targetEntity.getSkills().buildPropertiesForDefense(_skill.getContainer().getActor(), _skill);
+
+		local bodyPart = ::Math.rand(1, 100) <= _propertiesForUse.getHitchance(::Const.BodyPart.Head) ? ::Const.BodyPart.Head : ::Const.BodyPart.Body;
+		local bodyPartDamageMult = _propertiesForUse.DamageAgainstMult[bodyPart];
+
+		local injuries;
+
+		if (_skill.m.InjuriesOnBody != null && bodyPart == ::Const.BodyPart.Body)
+		{
+			injuries = _skill.m.InjuriesOnBody;
+		}
+		else if (_skill.m.InjuriesOnHead != null && bodyPart == ::Const.BodyPart.Head)
+		{
+			injuries = _skill.m.InjuriesOnHead;
+		}
+
+		local hitInfo = clone ::Const.Tactical.HitInfo;
+
+		// MV: Added
+		hitInfo.MV_PropertiesForUse = _propertiesForUse;
+		hitInfo.MV_PropertiesForDefense = _propertiesForDefense;
+
+		// MV: Extracted the calculation of DamageRegular, DamageArmor, DamageDirect
+		hitInfo.DamageRegular = _skill.MV_getDamageRegular(_propertiesForUse, _targetEntity);
+		hitInfo.DamageArmor = _skill.MV_getDamageArmor(_propertiesForUse, _targetEntity);
+		hitInfo.DamageDirect = _skill.MV_getDamageDirect(_propertiesForUse, _targetEntity);
+		hitInfo.DamageFatigue = ::Const.Combat.FatigueReceivedPerHit * _propertiesForUse.FatigueDealtPerHitMult;
+		hitInfo.DamageMinimum = _propertiesForUse.DamageMinimum;
+		hitInfo.BodyPart = bodyPart;
+		hitInfo.BodyDamageMult = bodyPartDamageMult;
+		hitInfo.FatalityChanceMult = _propertiesForUse.FatalityChanceMult;
+		hitInfo.Injuries = injuries;
+		hitInfo.InjuryThresholdMult = _propertiesForUse.ThresholdToInflictInjuryMult;
+		hitInfo.Tile = _targetEntity == null ? null : _targetEntity.getTile();
+
+		return hitInfo;
+	}
 });
 
 // MV: Modularized

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -12,7 +12,7 @@
 		local d = _target.getSkills().buildPropertiesForDefense(this.getContainer().getActor(), this);
 
 		// Set the damage in the properties to the average damage so that our MV_getDamageXYZ functions always roll the average damage
-		local damageRegularAvg = ::Math.floor((p.DamageRegularMin + p.DamageRegularMax) * 0.5);
+		local damageRegularAvg = ::Math.floor((p.DamageRegularMin + p.DamageRegularMax * p.DamageTooltipMaxMult) * 0.5);
 		p.DamageRegularMin = damageRegularAvg;
 		p.DamageRegularMax = damageRegularAvg;
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -2,8 +2,11 @@
 	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
-	q.MV_getDamageRegular <- { function MV_getDamageRegular( _properties, _targetEntity = null )
+	q.MV_getDamageRegular <- { function MV_getDamageRegular( _properties = null, _targetEntity = null )
 	{
+		if (_properties == null)
+			_properties = this.getContainer().buildPropertiesForUse(this, _targetEntity);
+
 		local damage = ::Math.rand(_properties.DamageRegularMin, _properties.DamageRegularMax) * _properties.DamageRegularMult;
 		if (_targetEntity != null && _targetEntity.isPlacedOnMap() && !::MSU.isNull(this.getContainer()) && this.getContainer().getActor().isPlacedOnMap())
 		{
@@ -15,8 +18,11 @@
 	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
-	q.MV_getDamageArmor <- { function MV_getDamageArmor( _properties, _targetEntity = null )
+	q.MV_getDamageArmor <- { function MV_getDamageArmor( _properties = null, _targetEntity = null )
 	{
+		if (_properties == null)
+			_properties = this.getContainer().buildPropertiesForUse(this, _targetEntity);
+
 		local damage = ::Math.rand(_properties.DamageRegularMin, _properties.DamageRegularMax) * _properties.DamageArmorMult;
 		if (_targetEntity != null && _targetEntity.isPlacedOnMap() && !::MSU.isNull(this.getContainer()) && this.getContainer().getActor().isPlacedOnMap())
 		{
@@ -28,8 +34,11 @@
 	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
-	q.MV_getDamageDirect <- { function MV_getDamageDirect( _properties, _targetEntity = null )
+	q.MV_getDamageDirect <- { function MV_getDamageDirect( _properties = null, _targetEntity = null )
 	{
+		if (_properties == null)
+			_properties = this.getContainer().buildPropertiesForUse(this, _targetEntity);
+
 		return ::Math.minf(1.0, _properties.DamageDirectMult * (this.getDirectDamage() + _properties.DamageDirectAdd + (this.isRanged() ? _properties.DamageDirectRangedAdd : _properties.DamageDirectMeleeAdd)));
 	}}.MV_getDamageDirect;
 

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -25,7 +25,7 @@
 		{
 			// The MV_initHitInfo function initializes the hitinfo from the attacker's perspective only i.e. outgoing damage
 			// just like in the vanilla skill.onScheduledTargetHit function
-			local hitInfo = this.MV_initHitInfo(p, _target);
+			local hitInfo = this.MV_initHitInfo(_target, p);
 			hitInfo.BodyPart = ::Const.BodyPart.Body;
 
 			// This will now use the outgoing hitInfo to prepare the correct properties for receiving damage

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -40,10 +40,6 @@
 
 			local ratioMult = bodyChance / 100.0;
 
-			// We use hitInfo.BodyPart instead of manually passing ::Const.BodyPart.Body
-			// because something in buildPropertiesForBeingHit might modify the body part e.g. for headless zombies Body may get changed to Head
-			armor += _target.getArmor(hitInfo.BodyPart) * ratioMult;
-
 			// These MV functions calculate the accurate damage received based on extraction of the calculations in actor.onDamageReceived
 			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * ratioMult;
 			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * ratioMult;
@@ -69,7 +65,6 @@
 
 			local ratioMult = headshotChance / 100.0;
 
-			armor += _target.getArmor(hitInfo.BodyPart) * ratioMult;
 			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * ratioMult;
 			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * ratioMult;
 		}

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -35,10 +35,11 @@
 			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
 
 			// Vanilla changes the HitInfo in certain skills in onBeforeTargetHit e.g. `pound` skill
-			// TODO: We can't call this skill_container event because it will set the skill_container IsUpdating back to false and trigger an update afterward so we need to find an alternative solution to this.
-			// An idea could be: add a new `container.MV_buildPropertiesForHitting` which calls buildPropertiesForUse and then additionally calls
-			// skill.onBeforeTargetHit and then sets the container IsUpdating back to its value which it had before.
+			// TODO: Some mods may do some state changes in `onBeforeTargetHit`, so I'm not sure if we can run this safely.
+			// local wasUpdating = this.getContainer().m.IsUpdating;
+			// this.getContainer().m.IsUpdating = true;
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);
+			// this.getContainer().m.IsUpdating = wasUpdating;
 
 			local ratioMult = bodyChance / 100.0;
 
@@ -55,7 +56,10 @@
 			local hitInfo = ::Const.Tactical.MV_initHitInfo(this, _target, p, d);
 
 			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
+			// local wasUpdating = this.getContainer().m.IsUpdating;
+			// this.getContainer().m.IsUpdating = true;
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);
+			// this.getContainer().m.IsUpdating = wasUpdating;
 
 			// I don't like this but this is to emulate vanilla behavior inside actor.onDamageReceived whereby the hitInfo.BodyDamageMult
 			// is manually set to 1.0 if the target is immune to criticals - Midas.

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -2,6 +2,8 @@
 	// MV: Modularized
 	// VanillaFix: Use buildPropertiesForBeingHit instead of buildPropertiesForDefense (https://steamcommunity.com/app/365360/discussions/1/604154904653626253/)
 	// Also rewrite the logic to be more accurate
+		// - Use MV functions to calculate damage to keep things DRY
+		// - Calculate accurate expected damage for body and head shots
 	q.getExpectedDamage = @() { function getExpectedDamage( _target )
 	{
 		local actor = this.getContainer().getActor();
@@ -607,6 +609,13 @@
 		}
 	}}.attackEntity;
 
+	// MV: Added
+	// Part of skill.onScheduledTargetHit modularization
+	// Similar to the vanilla instantiation and calculation of HitInfo in onScheduledTargetHit,
+	// this is meant to return the HitInfo from the perspective of the attacker i.e. outgoing damage.
+	// We use our MV functions to calculate damage to keep things DRY.
+		// _propertiesForUse parameter is just there so that when called from onScheduledTargetHit we don't have to
+		// calculate the properties again as they are already present in that function.
 	q.MV_initHitInfo <- function( _targetEntity, _propertiesForUse = null )
 	{
 		if (_propertiesForUse == null)
@@ -657,6 +666,7 @@
 			return;
 		}
 
+		// MV: Extracted the initialization and calculation of HitInfo into a new function
 		local hitInfo = this.MV_initHitInfo(_info.TargetEntity, _info.Properties);
 
 		// MV: Added

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -4,6 +4,7 @@
 	// Also rewrite the logic to be more accurate
 		// - Use MV functions to calculate damage to keep things DRY
 		// - Calculate accurate expected damage for body and head shots
+	// TODO: Things like Split Man are not accounted for anywhere. Some kind of framework should be made for them?
 	q.getExpectedDamage = @() { function getExpectedDamage( _target )
 	{
 		local actor = this.getContainer().getActor();

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -636,7 +636,7 @@
 
 		_info.Container.onBeforeTargetHit(_info.Skill, _info.TargetEntity, hitInfo);
 		local pos = _info.TargetEntity.getPos();
-		local hasArmorHitSound = _info.TargetEntity.getItems().getAppearance().ImpactSound[bodyPart].len() != 0;
+		local hasArmorHitSound = _info.TargetEntity.getItems().getAppearance().ImpactSound[hitInfo.BodyPart].len() != 0;
 		_info.TargetEntity.onDamageReceived(_info.User, _info.Skill, hitInfo);
 
 		if (hitInfo.DamageInflictedHitpoints >= this.Const.Combat.PlayHitSoundMinDamage)

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -34,8 +34,10 @@
 			// This will now use the outgoing hitInfo to prepare the correct properties for receiving damage
 			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
 
-			// Vanilla changes the HitInfo in certain skills in onBeforeTargetHit e.g. `pound` skill
-			// TODO: Some mods may do some state changes in `onBeforeTargetHit`, so I'm not sure if we can run this safely.
+			// Vanilla changes the HitInfo in certain skills in onBeforeTargetHit e.g. `pound` and `gash_skill`.
+			// Vanilla also spawns icon for `perk_coup_de_grace` in `onBeforeTargetHit`.
+			// Some mods may do some state changes in `onBeforeTargetHit`.
+			// TODO: Therefore I am not sure how we can account for these. Calling this function doesn't seem safe.
 			// local wasUpdating = this.getContainer().m.IsUpdating;
 			// this.getContainer().m.IsUpdating = true;
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -8,6 +8,7 @@
 	{
 		local actor = this.getContainer().getActor();
 		local p = this.getContainer().buildPropertiesForUse(this, _target);
+		local d = _target.getSkills().buildPropertiesForDefense(this.getContainer().getActor(), this);
 
 		// Set the damage in the properties to the average damage so that our MV_getDamageXYZ functions always roll the average damage
 		local damageRegularAvg = ::Math.floor((p.DamageRegularMin + p.DamageRegularMax) * 0.5);
@@ -27,9 +28,10 @@
 			// just like in the vanilla skill.onScheduledTargetHit function
 			local hitInfo = this.MV_initHitInfo(_target, p);
 			hitInfo.BodyPart = ::Const.BodyPart.Body;
+			hitInfo.MV_PropertiesForDefense = d;
 
 			// This will now use the outgoing hitInfo to prepare the correct properties for receiving damage
-			_target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
+			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
 
 			// Vanilla changes the HitInfo in certain skills in onBeforeTargetHit e.g. `pound` skill
 			// TODO: We can't call this skill_container event because it will set the skill_container IsUpdating back to false and trigger an update afterward so we need to find an alternative solution to this.
@@ -51,8 +53,9 @@
 			// Same process as above but with a new HitInfo object, now with forcing the body part to be Head
 			local hitInfo = this.MV_initHitInfo(p, _target);
 			hitInfo.BodyPart = ::Const.BodyPart.Head;
+			hitInfo.MV_PropertiesForDefense = d;
 
-			_target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
+			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);
 
 			// I don't like this but this is to emulate vanilla behavior inside actor.onDamageReceived whereby the hitInfo.BodyDamageMult

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -18,14 +18,9 @@
 		local armorDamage = 0;
 		local hitpointDamage = 0;
 
-		local bodyChance = 100;
 		local headshotChance = p.getHitchance(::Const.BodyPart.Head);
-		if (_target.getCurrentProperties().IsImmuneToCriticals || _target.getCurrentProperties().IsImmuneToHeadshots)
-		{
-			headshotChance = 0;
-		}
-
 		local bodyChance = 100 - headshotChance;
+
 		if (bodyChance != 0)
 		{
 			// The MV_initHitInfo function initializes the hitinfo from the attacker's perspective only i.e. outgoing damage
@@ -59,6 +54,16 @@
 
 			_target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);
+
+			// I don't like this but this is to emulate vanilla behavior inside actor.onDamageReceived whereby the hitInfo.BodyDamageMult
+			// is manually set to 1.0 if the target is immune to criticals - Midas.
+			// NOTE: Using `getCurrentProperties()` here has a caveat with split-body enemies i.e. Lindwurm Tail and Lindwurm
+			// whereby when called for Lindwurm Tail this will return the properties of the Lindwurm.
+			if (_target.getCurrentProperties().IsImmuneToCriticals || _target.getCurrentProperties().IsImmuneToHeadshots)
+			{
+				hitInfo.BodyDamageMult = 1.0;
+			}
+
 			armor += _target.getArmor(hitInfo.BodyPart) * headshotChance / 100.0;
 			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * headshotChance / 100.0;
 			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * headshotChance / 100.0;

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -39,13 +39,15 @@
 			// skill.onBeforeTargetHit and then sets the container IsUpdating back to its value which it had before.
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);
 
+			local ratioMult = bodyChance / 100.0;
+
 			// We use hitInfo.BodyPart instead of manually passing ::Const.BodyPart.Body
 			// because something in buildPropertiesForBeingHit might modify the body part e.g. for headless zombies Body may get changed to Head
-			armor += _target.getArmor(hitInfo.BodyPart) * bodyChance / 100.0;
+			armor += _target.getArmor(hitInfo.BodyPart) * ratioMult;
 
 			// These MV functions calculate the accurate damage received based on extraction of the calculations in actor.onDamageReceived
-			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * bodyChance / 100.0;
-			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * bodyChance / 100.0;
+			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * ratioMult;
+			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * ratioMult;
 		}
 
 		if (headshotChance != 0)
@@ -67,9 +69,11 @@
 				hitInfo.BodyDamageMult = 1.0;
 			}
 
-			armor += _target.getArmor(hitInfo.BodyPart) * headshotChance / 100.0;
-			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * headshotChance / 100.0;
-			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * headshotChance / 100.0;
+			local ratioMult = headshotChance / 100.0;
+
+			armor += _target.getArmor(hitInfo.BodyPart) * ratioMult;
+			armorDamage += _target.MV_calcArmorDamageReceived(this, hitInfo) * ratioMult;
+			hitpointDamage += _target.MV_calcHitpointsDamageReceived(this, hitInfo) * ratioMult;
 		}
 
 		/*

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -27,8 +27,9 @@
 		{
 			// The MV_initHitInfo function initializes the hitinfo from the attacker's perspective only i.e. outgoing damage
 			// just like in the vanilla skill.onScheduledTargetHit function
+			p.HitChance[::Const.BodyPart.Head] = 0;
+			p.HitChance[::Const.BodyPart.Body] = 100;
 			local hitInfo = ::Const.Tactical.MV_initHitInfo(this, _target, p, d);
-			hitInfo.BodyPart = ::Const.BodyPart.Body;
 
 			// This will now use the outgoing hitInfo to prepare the correct properties for receiving damage
 			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
@@ -49,8 +50,9 @@
 		if (headshotChance != 0)
 		{
 			// Same process as above but with a new HitInfo object, now with forcing the body part to be Head
+			p.HitChance[::Const.BodyPart.Head] = 100;
+			p.HitChance[::Const.BodyPart.Body] = 0;
 			local hitInfo = ::Const.Tactical.MV_initHitInfo(this, _target, p, d);
-			hitInfo.BodyPart = ::Const.BodyPart.Head;
 
 			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);
 			// this.getContainer().onBeforeTargetHit(this, _target, hitInfo);

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -28,7 +28,9 @@
 			// The MV_initHitInfo function initializes the hitinfo from the attacker's perspective only i.e. outgoing damage
 			// just like in the vanilla skill.onScheduledTargetHit function
 			p.HitChance[::Const.BodyPart.Head] = 0;
+			p.HitChanceMult[::Const.BodyPart.Head] = 0.0;
 			p.HitChance[::Const.BodyPart.Body] = 100;
+			p.HitChanceMult[::Const.BodyPart.Body] = 1.0;
 			local hitInfo = ::Const.Tactical.MV_initHitInfo(this, _target, p, d);
 
 			// This will now use the outgoing hitInfo to prepare the correct properties for receiving damage
@@ -54,7 +56,9 @@
 		{
 			// Same process as above but with a new HitInfo object, now with forcing the body part to be Head
 			p.HitChance[::Const.BodyPart.Head] = 100;
+			p.HitChanceMult[::Const.BodyPart.Head] = 1.0;
 			p.HitChance[::Const.BodyPart.Body] = 0;
+			p.HitChanceMult[::Const.BodyPart.Body] = 0.0;
 			local hitInfo = ::Const.Tactical.MV_initHitInfo(this, _target, p, d);
 
 			hitInfo.MV_PropertiesForBeingHit = _target.getSkills().buildPropertiesForBeingHit(actor, this, hitInfo);


### PR DESCRIPTION
This is a draft PR to get your first impressions and feedback/ideas on how to approach this. 

This PR intends to completely rewrite the `getExpectedDamage` logic to utilize modularized DRY functions and also to make the logic be more accurate. The vanilla implementation has several issues including but not limited to:
- Using wrong properties (`buildPropertiesForDefense` instead of `buildPropertiesForBeingHit`).
- Not accounting for many vanilla damage related fields e.g. `skill.m.DamageMinimum` and `properties.DamageRegularReduction` and others.

Related discussion on Discord: https://discord.com/channels/965324395851694140/1000342646184747008/1367125435070287995