### PR TITLE
fix(vanilla): calling onEntityEntersFirstSlot on entity pushed back

### DIFF
--- a/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -1,5 +1,25 @@
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
 	::ModularVanilla.MH.hook("scripts/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar", function(q) {
+		q.m.__MV_FirstSlotEntityID <- null;
+
+		// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/604155219069147354/
+		// Vanilla calls this function whenever an entity who is visible in the turn sequence bar is pushed back in
+		// the sequence resulting in calling `entity.onTurnResumed` on the currently active actor prematurely.
+		// Our fix is a bandaid which returns early when calling this function on an entity already in the first slot.
+		q.onEntityEntersFirstSlot = @(__original) function( _entityId )
+		{
+			if (_entityId == this.m.__MV_FirstSlotEntityID)
+			{
+				local entity = this.findEntityByID(this.m.AllEntities, _entityId);
+				if (entity != null)
+				{
+					return this.convertEntityToUIData(entity.entity, entity.index == this.m.CurrentEntities.len() - 1);
+				}
+			}
+			this.m.__MV_FirstSlotEntityID = _entityId;
+			return __original(_entityId);
+		}
+
 		// MV: Changed
 		// part of affordability preview system
 		q.setActiveEntityCostsPreview = @() function( _costsPreview )

--- a/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -20,6 +20,24 @@
 			return __original(_entityId);
 		}
 
+		q.initNextRound = @(__original) function()
+		{
+			this.m.__MV_FirstSlotEntityID = null;
+			__original();
+		}
+
+		q.initNextTurn = @(__original) function( _force = false )
+		{
+			this.m.__MV_FirstSlotEntityID = null;
+			__original(_force);
+		}
+
+		q.initNextTurnBecauseOfWait = @(__original) function()
+		{
+			this.m.__MV_FirstSlotEntityID = null;
+			__original();
+		}
+
 		// MV: Changed
 		// part of affordability preview system
 		q.setActiveEntityCostsPreview = @() function( _costsPreview )


### PR DESCRIPTION
Vanilla calls this function whenever an entity who is visible in the turn sequence bar is pushed back in the sequence resulting in calling `entity.onTurnResumed` on the currently active actor prematurely.

Our fix is a bandaid which returns early when calling this function on an entity already in the first slot.

Bug report: https://steamcommunity.com/app/365360/discussions/1/604155219069147354/