### PR TITLE
fix: preview skill potentially becoming null while previewing a skill

### DIFF
--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -73,7 +73,7 @@
 	// MV: Added
 	q.getPreviewSkill <- function()
 	{
-		return this.m.MV_PreviewSkill;
+		return ::MSU.isNull(this.m.MV_PreviewSkill) ? null : this.m.MV_PreviewSkill.get();
 	}
 
 	// MV: Added

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -67,7 +67,7 @@
 	// MV: Added
 	q.isPreviewing <- function()
 	{
-		return this.m.MV_IsPreviewing;
+		return this.m.MV_IsPreviewing && (!::MSU.isNull(this.getPreviewSkill()) || !::MSU.isNull(this.getPreviewMovement()));
 	}
 
 	// MV: Added

--- a/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -20,7 +20,7 @@
 
 			if ("SkillID" in _costsPreview)
 			{
-				activeEntity.m.MV_PreviewSkill = activeEntity.getSkills().getSkillByID(_costsPreview.SkillID);
+				activeEntity.m.MV_PreviewSkill = ::MSU.asWeakTableRef(activeEntity.getSkills().getSkillByID(_costsPreview.SkillID));
 				activeEntity.setPreviewSkillID(_costsPreview.SkillID);
 			}
 			else


### PR DESCRIPTION
This can happen due to mods which allow swapping items via a hotkey during a preview resulting in the previewed skill being removed from the actor. Therefore, now we store a WeakTableRef instead of a strong ref to the skill and only return true for `isPreviewing()` when either previewed skill or movement is not null.

Relevant bug report on Reforged Discord: https://discord.com/channels/1006908336991645757/1367263314018828388