### PR TITLE
feat: allow backgrounds to return a different ID for events

### DIFF
--- a/mod_modular_vanilla/config/private_globals.nut
+++ b/mod_modular_vanilla/config/private_globals.nut
@@ -1,0 +1,4 @@
+::MSU.Table.merge(::ModularVanilla, {
+	// Set during event onUpdateScore and onPrepare to allow backgrounds to return a different ID for themselves
+	__EventIDForBG = null
+});

--- a/mod_modular_vanilla/hooks/events/event.nut
+++ b/mod_modular_vanilla/hooks/events/event.nut
@@ -1,0 +1,21 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hookTree("scripts/events/event", function (q) {
+		// MV: Changed
+		// part of character_background.MV_getIDForEvent framework
+		q.onUpdateScore = @(__original) function()
+		{
+			::ModularVanilla.__EventIDForBG = this.getID();
+			__original();
+			::ModularVanilla.__EventIDForBG = null;
+		}
+
+		// MV: Changed
+		// part of character_background.MV_getIDForEvent framework
+		q.onPrepare = @(__original) function()
+		{
+			::ModularVanilla.__EventIDForBG = this.getID();
+			__original();
+			::ModularVanilla.__EventIDForBG = null;
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/backgrounds/character_background.nut
+++ b/mod_modular_vanilla/hooks/skills/backgrounds/character_background.nut
@@ -1,0 +1,21 @@
+::ModularVanilla.MH.hook("scripts/skills/character_background", function (q) {
+	// MV: Added
+	// Allows this background to return a different ID during events so that new backgrounds
+	// added by mods work seamlessly with events that check for particular background IDs in their conditions
+	q.MV_getIDForEvent <- function( _eventID )
+	{
+		return this.m.ID;
+	}
+});
+
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hook("scripts/skills/character_background", function (q) {
+		// MV: Changed
+		// part of character_background.MV_getIDForEvent framework
+		// Return the ID from MV_getIDForEvent during events being set up
+		q.getID  = @(__original) function()
+		{
+			return ::ModularVanilla.__EventIDForBGProxy != null ? this.MV_getIDForEvent(::ModularVanilla.__EventIDForBG) : __original();
+		}
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/backgrounds/character_background.nut
+++ b/mod_modular_vanilla/hooks/skills/backgrounds/character_background.nut
@@ -15,7 +15,7 @@
 		// Return the ID from MV_getIDForEvent during events being set up
 		q.getID  = @(__original) function()
 		{
-			return ::ModularVanilla.__EventIDForBGProxy != null ? this.MV_getIDForEvent(::ModularVanilla.__EventIDForBG) : __original();
+			return ::ModularVanilla.__EventIDForBG != null ? this.MV_getIDForEvent(::ModularVanilla.__EventIDForBG) : __original();
 		}
 	});
 });


### PR DESCRIPTION
This enables backgrounds added by mods to seamlessly integrate into vanilla events or events from other mods which check for the existence of certain backgrounds via IDs.

Note: We only add handling for returning a different ID. Other fields such as `isLowborn` etc. are not handled. Design-wise one would expect that a background that wants to behave as a different background would probably have those fields set up in its definition similar to the other background.