### PR TITLE
feat!: remove skill container event for strength mult and add property

### DIFF
--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -10,3 +10,8 @@
 	MV_DiversionHitChanceAdd = -15,
 	MV_DiversionDamageMult = 0.75
 });
+
+::MSU.Table.merge(::Const.CharacterProperties, {
+	// Part of modularization of player_party.updateStrength
+	MV_StrengthMult = 1.0
+});

--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -12,7 +12,7 @@
 	// Returns the actual strength of this character, using raw strength and any multipliers
 	q.MV_getStrength <- function()
 	{
-		return this.MV_getStrengthRaw() * this.getSkills().MV_getPlayerPartyStrengthMult();
+		return this.MV_getStrengthRaw() * this.getCurrentProperties().MV_StrengthMult;
 	}
 
 	// MV: Added

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -1,12 +1,5 @@
 ::ModularVanilla.MH.hook("scripts/skills/skill", function (q) {
 	// MV: Added
-	// part of player_party.updateStrength modularization
-	q.MV_getPlayerPartyStrengthMult <- function()
-	{
-		return 1.0;
-	}
-
-	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
 	q.MV_getDamageRegular <- function( _properties, _targetEntity = null )

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -32,24 +32,6 @@
 		}
 		this.m.IsUpdating = wasUpdating;
 	}
-
-	// MV: Added
-	// part of player_party.updateStrength modularization
-	q.MV_getPlayerPartyStrengthMult <- function()
-	{
-		local ret = 1.0;
-
-		local wasUpdating = this.m.IsUpdating;
-		this.m.IsUpdating = true;
-		foreach (s in this.m.Skills)
-		{
-			if (!s.isGarbage())
-				ret *= s.MV_getPlayerPartyStrengthMult();
-		}
-		this.m.IsUpdating = wasUpdating;
-
-		return ret;
-	}
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {


### PR DESCRIPTION
It is much more efficient for skills to simply modify this multiplier during their `onUpdate` or `onAfterUpdate` functions instead of triggering a standalone event every time `player_party.updateStrength()` is called.