### PR TITLE
fix(vanilla): dislocated shoulder setting action points during onUpdate

### DIFF
--- a/mod_modular_vanilla/hooks/skills/injury/dislocated_shoulder_injury.nut
+++ b/mod_modular_vanilla/hooks/skills/injury/dislocated_shoulder_injury.nut
@@ -1,0 +1,23 @@
+::ModularVanilla.MH.hook("scripts/skills/injury/dislocated_shoulder_injury", function (q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/555745444093769921/
+	// This fix is composed of changes to both `onUpdate` and `onAfterUpdate`.
+	// We move the `setActionPoints` to `onAfterUpdate` so that all changes to `_properties.ActionPoints`
+	// from all skills are properly accounted for.
+	q.onUpdate = @() { function onUpdate( _properties )
+	{
+		this.injury.onUpdate(_properties);
+
+		if (!_properties.IsAffectedByInjuries || this.m.IsFresh && !_properties.IsAffectedByFreshInjuries)
+		{
+			return;
+		}
+
+		_properties.ActionPoints -= 3;
+	}}.onUpdate;
+
+	q.onAfterUpdate = @(__original) { function onAfterUpdate( _properties )
+	{
+		__original(_properties);
+		this.getContainer().getActor().setActionPoints(::Math.min(_properties.ActionPoints, this.getContainer().getActor().getActionPoints()));
+	}}.onAfterUpdate;
+});


### PR DESCRIPTION
This leads to changes to `_properties.ActionPoints` from other skills to not be properly taken into account.

Bug report for vanilla: https://steamcommunity.com/app/365360/discussions/1/555745444093769921/

Relevant bug report on Reforged discord: https://discord.com/channels/1006908336991645757/1383272361033203742