### PR TITLE
feat: modularize morale check system

### DIFF
--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -16,7 +16,31 @@ addMoraleCheckType("MV_Surround");
 	MV_DiversionDamageMult = 0.75
 });
 
+local original_getClone = ::Const.CharacterProperties.getClone;
 ::MSU.Table.merge(::Const.CharacterProperties, {
+	function getClone()
+	{
+		local ret = original_getClone();
+		ret.MV_MoraleCheckBraveryCallbacks = clone this.MV_MoraleCheckBraveryCallbacks;
+		return ret;
+	},
+
 	// Part of modularization of player_party.updateStrength
 	MV_StrengthMult = 1.0
+	/*
+	You push functions to this array during `skill.onUpdate` or `skill.onAfterUpdate`.
+	These are then used to modify the Bravery during actor.checkMorale.
+	The functions pushed look like this:
+		function( _change, _type )
+		_change is the _change parameter in `actor.checkMorale`.
+		_type is the _type parameter in `actor.checkMorale`.
+	The functions return a table with this signature:
+	{
+		Add = <integer>
+		Mult = <float>
+	}
+	// Add is then added to Bravery during actor.checkMorale
+	// whereas Mult is multiplied with the BraveryMult.
+	*/
+	MV_MoraleCheckBraveryCallbacks = []
 });

--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -1,8 +1,13 @@
+local function addMoraleCheckType( _key )
+{
+	::Const.MoraleCheckType[_key] <- ::Const.MoraleCheckType.len();
+	::Const.CharacterProperties.MoraleCheckBravery.push(0);
+	::Const.CharacterProperties.MoraleCheckBraveryMult.push(1.0);
+}
+
 // Add a new morale check type for being surrounded. Is used during
 // actor.onMovementFinish
-::Const.MoraleCheckType.MV_Surround <- ::Const.MoraleCheckType.len();
-::Const.CharacterProperties.MoraleCheckBravery.push(0);
-::Const.CharacterProperties.MoraleCheckBraveryMult.push(1.0);
+addMoraleCheckType("MV_Surround");
 
 ::MSU.Table.merge(::Const.Combat, {
 	MV_HitChanceMin = 5,

--- a/mod_modular_vanilla/hooks/config/character.nut
+++ b/mod_modular_vanilla/hooks/config/character.nut
@@ -22,6 +22,7 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	{
 		local ret = original_getClone();
 		ret.MV_MoraleCheckBraveryCallbacks = clone this.MV_MoraleCheckBraveryCallbacks;
+		ret.MV_ForbiddenMoraleStates = clone this.MV_ForbiddenMoraleStates;
 		return ret;
 	},
 
@@ -42,5 +43,8 @@ local original_getClone = ::Const.CharacterProperties.getClone;
 	// Add is then added to Bravery during actor.checkMorale
 	// whereas Mult is multiplied with the BraveryMult.
 	*/
-	MV_MoraleCheckBraveryCallbacks = []
+	MV_MoraleCheckBraveryCallbacks = [],
+	// During actor.setMoraleState if the passed morale state is found in this
+	// array, the morale state will not be set to that value..
+	MV_ForbiddenMoraleStates = []
 });

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -612,6 +612,60 @@
 		this.m.IsMoving = false;
 	}}.onMovementFinish;
 
+	// MV: Modularized
+	// Extracted the removal of effects into a new skill_container.MV_onMoraleStateChanged event
+	q.setMoraleState = @() { function setMoraleState( _m )
+	{
+		if (this.m.MoraleState == _m)
+		{
+			return;
+		}
+
+		/*
+		This vanilla part is disabled because the removal of these skills is now handled
+		directly within those skills thanks to our new skill_container.MV_onMoraleStateChanged event
+
+		NOTE: return_favor_effect does not exist in vanilla codebase so we have not hooked it!
+
+		if (_m == this.Const.MoraleState.Fleeing)
+		{
+			this.m.Skills.removeByID("effects.shieldwall");
+			this.m.Skills.removeByID("effects.spearwall");
+			this.m.Skills.removeByID("effects.riposte");
+			this.m.Skills.removeByID("effects.return_favor");
+			this.m.Skills.removeByID("effects.indomitable");
+		}
+		*/
+
+		// MV: Added, store oldMoraleState in local var to later pass to skill_container.MV_onMoraleStateChanged
+		local oldMoraleState = this.m.MoraleState;
+
+		this.m.MoraleState = _m;
+		local morale = this.getSprite("morale");
+
+		if (this.Const.MoraleStateBrush[_m].len() != 0)
+		{
+			if (_m == this.Const.MoraleState.Confident)
+			{
+				morale.setBrush(this.m.ConfidentMoraleBrush);
+			}
+			else
+			{
+				morale.setBrush(this.Const.MoraleStateBrush[_m]);
+			}
+
+			morale.Visible = true;
+		}
+		else
+		{
+			morale.Visible = false;
+		}
+
+		// MV: Changed
+		// vanilla does this.m.Skills.update() here but we trigger our new skill container event which calls update after it
+		this.getSkills().MV_onMoraleStateChanged(oldMoraleState);
+	}}.setMoraleState;
+
 	// MV: Extracted
 	// Part of modularization of actor.checkMorale
 	// The logic is the same as the vanilla guard statements at the beginning of that function

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -694,7 +694,18 @@
 			return false;
 		}
 
-		local bravery = (this.getBravery() + this.getCurrentProperties().MoraleCheckBravery[_type]) * this.getCurrentProperties().MoraleCheckBraveryMult[_type];
+		local bravery = this.getBravery() + this.getCurrentProperties().MoraleCheckBravery[_type];
+		local mult = this.getCurrentProperties().MoraleCheckBraveryMult[_type];
+
+		// MV: Added we have added callbacks to character properties to modify the bravery
+		// via functions based on the _change and _type. These functions are called and applied here.
+		foreach (callback in this.getCurrentProperties().MV_MoraleCheckBraveryCallbacks)
+		{
+			local result = callback(_change, _type);
+			bravery += result.Add;
+			mult *= result.Mult;
+		}
+		bravery *= mult;
 
 		// Weird vanilla edge case - no idea what it is for.
 		if (bravery > 500)

--- a/mod_modular_vanilla/hooks/entity/tactical/actor.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/actor.nut
@@ -611,4 +611,286 @@
 		this.setDirty(true);
 		this.m.IsMoving = false;
 	}}.onMovementFinish;
+
+	// MV: Extracted
+	// Part of modularization of actor.checkMorale
+	// The logic is the same as the vanilla guard statements at the beginning of that function
+	// but we have rewritten the code to be more optimized.
+	q.MV_isMoraleCheckValid <- { function MV_isMoraleCheckValid( _change, _type )
+	{
+		if (this.getMoraleState() == this.Const.MoraleState.Ignore)
+		{
+			return false;
+		}
+
+		if (_change > 0)
+		{
+			// actor.getMaxMoraleState is an MSU-added function
+			if (this.getMoraleState() == this.Const.MoraleState.Confident || this.getMoraleState() >= this.getMaxMoraleState())
+			{
+				return false;
+			}
+
+			if (this.isPlayerControlled())
+			{
+				local myTile = this.getTile();
+				if (myTile.SquareCoords.X == 0 || myTile.SquareCoords.Y == 0 || myTile.SquareCoords.X == 31 || myTile.SquareCoords.Y == 31)
+				{
+					return false;
+				}
+			}
+		}
+		else if (_change < 0 || _change == 1)
+		{
+			return this.getMoraleState() != this.Const.MoraleState.Fleeing;
+		}
+
+		return true;
+	}}.MV_isMoraleCheckValid;
+
+	// MV: Extracted
+	// Part of modularization of actor.checkMorale
+	// The logic is the same as in vanilla to adjust the difficulty of the morale check
+	// using the number of adjacent enemies and their Threat.
+	q.MV_getMoraleCheckThreat <- { function MV_getMoraleCheckThreat( _change, _type )
+	{
+		local self = this;
+		local adjacentOpponents = ::Tactical.Entities.getAdjacentActors(this.getTile()).filter(@(_, _a) !_a.isAlliedWith(self) && _a.getMoraleState() != ::Const.MoraleState.Fleeing);
+
+		local threatBonus = 0;
+		foreach (o in adjacentOpponents)
+		{
+			threatBonus += o.getCurrentProperties().Threat;
+		}
+
+		return adjacentOpponents.len() * ::Const.Morale.OpponentsAdjacentMult + threatBonus;
+	}}.MV_getMoraleCheckThreat;
+
+	// MV: Extracted
+	// Part of modularization of actor.checkMorale
+	// The logic is the same as in vanilla to adjust the difficulty of the morale check
+	// using the number of adjacent allies.
+	q.MV_getMoraleCheckSupport <- { function MV_getMoraleCheckSupport( _change, _type )
+	{
+		if (_change > 0)
+			return 0;
+
+		local self = this;
+		return ::Tactical.Entities.getAdjacentActors(this.getTile()).filter(@(_, _a) _a.isAlliedWith(self)).len() * ::Const.Morale.AlliesAdjacentMult;
+	}}.MV_getMoraleCheckSupport;
+
+	// MV: Modularized
+	q.checkMorale = @() { function checkMorale( _change, _difficulty, _type = this.Const.MoraleCheckType.Default, _showIconBeforeMoraleIcon = "", _noNewLine = false )
+	{
+		if (!this.isAlive() || this.isDying())
+		{
+			return false;
+		}
+
+		// MV: Extracted
+		// All the various vanilla guard statements have been pulled into this extracted function
+		if (!this.MV_isMoraleCheckValid(_change, _type))
+		{
+			return false;
+		}
+
+		local bravery = (this.getBravery() + this.getCurrentProperties().MoraleCheckBravery[_type]) * this.getCurrentProperties().MoraleCheckBraveryMult[_type];
+
+		// Weird vanilla edge case - no idea what it is for.
+		if (bravery > 500)
+		{
+			if (_change != 0)
+				return false;
+			else
+				return true;
+		}
+
+		/*
+		This part has been extracted into MV_getMoraleCheckThreat and MV_getMoraleCheckSupport functions
+
+		local myTile = this.getTile();
+		local numOpponentsAdjacent = 0;
+		local numAlliesAdjacent = 0;
+		local threatBonus = 0;
+
+		for( local i = 0; i != 6; i++ )
+		{
+			if (!myTile.hasNextTile(i))
+				continue;
+
+			local tile = myTile.getNextTile(i);
+
+			if (tile.IsOccupiedByActor && tile.getEntity().getMoraleState() != this.Const.MoraleState.Fleeing)
+			{
+				if (tile.getEntity().isAlliedWith(this))
+				{
+					numAlliesAdjacent++;
+				}
+				else
+				{
+					numOpponentsAdjacent++;
+					threatBonus += tile.getEntity().getCurrentProperties().Threat;
+				}
+			}
+		}
+		*/
+
+		_difficulty *= this.getCurrentProperties().MoraleEffectMult;
+
+		// MV: Changed
+		// Vanilla rewrites the chance equation separately in each if/else block. We extract it out here for better readability
+		local chance = ::Math.minf(95, bravery + _difficulty - this.MV_getMoraleCheckThreat(_change, _type) + this.MV_getMoraleCheckSupport(_change, _type));
+
+		if (_change > 0)
+		{
+			if (this.Math.rand(1, 100) > chance)
+			{
+				if (this.Math.rand(1, 100) > this.m.CurrentProperties.RerollMoraleChance || this.Math.rand(1, 100) > chance)
+				{
+					return false;
+				}
+			}
+		}
+		else if (_change < 0)
+		{
+			if (this.Math.rand(1, 100) <= chance)
+			{
+				return false;
+			}
+
+			if (this.Math.rand(1, 100) <= this.m.CurrentProperties.RerollMoraleChance && this.Math.rand(1, 100) <= chance)
+			{
+				return false;
+			}
+		}
+		else if (this.Math.rand(1, 100) <= chance)
+		{
+			return true;
+		}
+		else if (this.Math.rand(1, 100) <= this.m.CurrentProperties.RerollMoraleChance && chance)
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+
+		local oldMoraleState = this.getMoraleState();
+
+		// MV: Use setMoraleState instead of the vanilla this.m.MoraleState =
+		this.setMoraleState(this.Math.min(this.Const.MoraleState.Confident, this.Math.max(0, oldMoraleState + _change)));
+		// this.m.MoraleState = this.Math.min(this.Const.MoraleState.Confident, this.Math.max(0, this.getMoraleState() + _change));
+		this.m.FleeingRounds = 0;
+
+		/* MV: This vanilla part is unnecessary as it is triggered due to us using setMoraleState above
+
+		// if (this.getMoraleState() == this.Const.MoraleState.Confident && oldMoraleState != this.Const.MoraleState.Confident && ("State" in this.World) && this.World.State != null && this.World.Ambitions.hasActiveAmbition() && this.World.Ambitions.getActiveAmbition().getID() == "ambition.oath_of_camaraderie")
+		// {
+		// 	this.World.Statistics.getFlags().increment("OathtakersBrosConfident");
+		// }
+		*/
+
+		if (oldMoraleState == this.Const.MoraleState.Fleeing && this.m.IsActingEachTurn)
+		{
+			this.setZoneOfControl(this.getTile(), this.hasZoneOfControl());
+
+			if (this.isPlayerControlled() || !this.isHiddenToPlayer())
+			{
+				if (_noNewLine)
+				{
+					this.Tactical.EventLog.logEx(this.Const.UI.getColorizedEntityName(this) + " has rallied");
+				}
+				else
+				{
+					this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + " has rallied");
+				}
+			}
+		}
+
+		/* MV: This vanilla part is unnecessary as it is triggered due to us using setMoraleState above
+
+		else if (this.getMoraleState() == this.Const.MoraleState.Fleeing)
+		{
+			this.setZoneOfControl(this.getTile(), this.hasZoneOfControl());
+			this.m.Skills.removeByID("effects.shieldwall");
+			this.m.Skills.removeByID("effects.spearwall");
+			this.m.Skills.removeByID("effects.riposte");
+			this.m.Skills.removeByID("effects.return_favor");
+			this.m.Skills.removeByID("effects.indomitable");
+		}
+
+		local morale = this.getSprite("morale");
+
+		if (this.Const.MoraleStateBrush[this.getMoraleState()].len() != 0)
+		{
+			if (this.getMoraleState() == this.Const.MoraleState.Confident)
+			{
+				morale.setBrush(this.m.ConfidentMoraleBrush);
+			}
+			else
+			{
+				morale.setBrush(this.Const.MoraleStateBrush[this.getMoraleState()]);
+			}
+
+			morale.Visible = true;
+		}
+		else
+		{
+			morale.Visible = false;
+		}
+		*/
+
+		if (this.isPlayerControlled() || !this.isHiddenToPlayer())
+		{
+			if (_noNewLine)
+			{
+				this.Tactical.EventLog.logEx(this.Const.UI.getColorizedEntityName(this) + this.Const.MoraleStateEvent[this.getMoraleState()]);
+			}
+			else
+			{
+				this.Tactical.EventLog.log(this.Const.UI.getColorizedEntityName(this) + this.Const.MoraleStateEvent[this.getMoraleState()]);
+			}
+
+			if (_showIconBeforeMoraleIcon != "")
+			{
+				this.Tactical.spawnIconEffect(_showIconBeforeMoraleIcon, this.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
+			}
+
+			if (_change > 0)
+			{
+				this.Tactical.spawnIconEffect(this.Const.Morale.MoraleUpIcon, this.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
+			}
+			else
+			{
+				this.Tactical.spawnIconEffect(this.Const.Morale.MoraleDownIcon, this.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
+			}
+		}
+
+		// this.m.Skills.update(); // Unnecessary due to our use of setMoraleState above which does a skill container update
+		this.setDirty(true);
+
+		if (this.getMoraleState() == this.Const.MoraleState.Fleeing && this.Tactical.TurnSequenceBar.getActiveEntity() != this)
+		{
+			this.Tactical.TurnSequenceBar.pushEntityBack(this.getID());
+		}
+
+		if (this.getMoraleState() == this.Const.MoraleState.Fleeing)
+		{
+			local actors = this.Tactical.Entities.getInstancesOfFaction(this.getFaction());
+
+			if (actors != null)
+			{
+				foreach( a in actors )
+				{
+					if (a.getID() != this.getID())
+					{
+						a.onOtherActorFleeing(this);
+					}
+				}
+			}
+		}
+
+		return true;
+	}}.checkMorale;
 });

--- a/mod_modular_vanilla/hooks/entity/tactical/player.nut
+++ b/mod_modular_vanilla/hooks/entity/tactical/player.nut
@@ -109,4 +109,52 @@
 			this.fillAttributeLevelUpValues(::Const.XP.MaxLevelWithPerkpoints - 1);
 		}
 	}}.setStartValuesEx;
+
+	q.setMoraleState = @() { function setMoraleState( _m )
+	{
+		if (this.getCurrentProperties().MV_ForbiddenMoraleStates.find(_m) != null)
+		{
+			return;
+		}
+
+	/*
+	This has been implemented in hooks on these skills using the properties.MV_ForbiddenMoraleStates
+
+		if (_m == this.Const.MoraleState.Confident && this.m.Skills.hasSkill("trait.insecure"))
+		{
+			return;
+		}
+	*/
+
+	/*
+	This has been implemented via mv_manager_skill_for_player using the skill.MV_onMoraleStateChanged event
+
+		if (_m == this.Const.MoraleState.Confident && ("State" in this.World) && this.World.State != null && this.World.Assets.getOrigin().getID() == "scenario.anatomists")
+		{
+			return;
+		}
+	*/
+
+	/*
+	This has been implemented in hooks on these skills
+
+		if (_m == this.Const.MoraleState.Fleeing && this.m.Skills.hasSkill("effects.ancient_priest_potion"))
+		{
+			return;
+		}
+
+		if (_m == this.Const.MoraleState.Fleeing && this.m.Skills.hasSkill("trait.oath_of_valor"))
+		{
+			return;
+		}
+
+
+		if (_m == this.Const.MoraleState.Confident && this.getMoraleState() != this.Const.MoraleState.Confident && this.isPlacedOnMap() && this.Time.getRound() >= 1 && ("State" in this.World) && this.World.State != null && this.World.Ambitions.hasActiveAmbition() && this.World.Ambitions.getActiveAmbition().getID() == "ambition.oath_of_camaraderie")
+		{
+			this.World.Statistics.getFlags().increment("OathtakersBrosConfident");
+		}
+	*/
+
+		this.actor.setMoraleState(_m);
+	}}.setMoraleState;
 });

--- a/mod_modular_vanilla/hooks/scenarios/world/anatomists_scenario.nut
+++ b/mod_modular_vanilla/hooks/scenarios/world/anatomists_scenario.nut
@@ -1,0 +1,18 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hookTree("scripts/scenarios/world/anatomists_scenario", function (q) {
+		q.onSpawnPlayer = @(__original) { function onSpawnPlayer()
+		{
+			__original();
+			foreach (bro in ::World.getPlayerRoster().getAll())
+			{
+				bro.getBaseProperties().MV_ForbiddenMoraleStates.push(::Const.MoraleState.Confident);
+			}
+		}}.onSpawnPlayer;
+
+		q.onHired = @(__original) { function onHired( _bro )
+		{
+			_bro.getBaseProperties().MV_ForbiddenMoraleStates.push(::Const.MoraleState.Confident);
+			__original(_bro);
+		}}.onHired;
+	});
+});

--- a/mod_modular_vanilla/hooks/skills/effects/ancient_priest_potion.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/ancient_priest_potion.nut
@@ -1,0 +1,7 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/ancient_priest_potion", function(q) {
+	q.onUpdate = @(__original) { function onUpdate( _properties )
+	{
+		__original(_properties);
+		_properties.MV_ForbiddenMoraleStates.push(::Const.MoraleState.Fleeing);
+	}}.onUpdate;
+});

--- a/mod_modular_vanilla/hooks/skills/effects/indomitable_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/indomitable_effect.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/indomitable_effect", function(q) {
+	// MV: Added
+	// Part of modularization of actor.setMoraleState
+	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )
+	{
+		if (this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Fleeing)
+		{
+			this.removeSelf();
+		}
+	}}.MV_onMoraleStateChanged;
+});

--- a/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/riposte_effect.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/riposte_effect", function(q) {
+	// MV: Added
+	// Part of modularization of actor.setMoraleState
+	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )
+	{
+		if (this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Fleeing)
+		{
+			this.removeSelf();
+		}
+	}}.MV_onMoraleStateChanged;
+});

--- a/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/shieldwall_effect.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/shieldwall_effect", function(q) {
+	// MV: Added
+	// Part of modularization of actor.setMoraleState
+	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )
+	{
+		if (this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Fleeing)
+		{
+			this.removeSelf();
+		}
+	}}.MV_onMoraleStateChanged;
+});

--- a/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
+++ b/mod_modular_vanilla/hooks/skills/effects/spearwall_effect.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.MH.hook("scripts/skills/effects/spearwall_effect", function(q) {
+	// MV: Added
+	// Part of modularization of actor.setMoraleState
+	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )
+	{
+		if (this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Fleeing)
+		{
+			this.removeSelf();
+		}
+	}}.MV_onMoraleStateChanged;
+});

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -1,5 +1,11 @@
 ::ModularVanilla.MH.hook("scripts/skills/skill", function (q) {
 	// MV: Added
+	// Part of modularization of actor.setMoraleState
+	q.MV_onMoraleStateChanged <- { function MV_onMoraleStateChanged( _oldState )
+	{
+	}}.MV_onMoraleStateChanged;
+
+	// MV: Added
 	// Part of skill.onScheduledTargetHit modularization.
 	// But useful on its own as well.
 	q.MV_getDamageRegular <- { function MV_getDamageRegular( _properties, _targetEntity = null )

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -32,6 +32,22 @@
 		}
 		this.m.IsUpdating = wasUpdating;
 	}}.onCostsPreview;
+
+	// MV: Added
+	// Part of modularization of actor.setMoraleState
+	q.MV_onMoraleStateChanged <- { function MV_onMoraleStateChanged( _oldState )
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+		foreach (s in this.m.Skills)
+		{
+			if (!s.isGarbage())
+				s.MV_onMoraleStateChanged(_oldState);
+		}
+		this.m.IsUpdating = wasUpdating;
+
+		this.update();
+	}}.MV_onMoraleStateChanged;
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {

--- a/mod_modular_vanilla/hooks/skills/traits/insecure_trait.nut
+++ b/mod_modular_vanilla/hooks/skills/traits/insecure_trait.nut
@@ -1,0 +1,7 @@
+::ModularVanilla.MH.hook("scripts/skills/traits/insecure_trait", function(q) {
+	q.onUpdate = @(__original) { function onUpdate( _properties )
+	{
+		__original(_properties);
+		_properties.MV_ForbiddenMoraleStates.push(::Const.MoraleState.Confident);
+	}}.onUpdate;
+});

--- a/mod_modular_vanilla/hooks/skills/traits/oath_of_camaraderie_trait.nut
+++ b/mod_modular_vanilla/hooks/skills/traits/oath_of_camaraderie_trait.nut
@@ -1,0 +1,9 @@
+::ModularVanilla.MH.hook("scripts/skills/traits/oath_of_camaraderie_trait", function(q) {
+	q.MV_onMoraleStateChanged = @() { function MV_onMoraleStateChanged( _oldState )
+	{
+		if (this.getContainer().getActor().getMoraleState() == ::Const.MoraleState.Confident && _oldState != ::Const.MoraleState.Confident && this.isPlacedOnMap() && ::Time.getRound() >= 1 && ("State" in ::World) && ::World.State != null && ::World.Ambitions.hasActiveAmbition() && ::World.Ambitions.getActiveAmbition().getID() == "ambition.oath_of_camaraderie")
+		{
+			::World.Statistics.getFlags().increment("OathtakersBrosConfident");
+		}
+	}}.MV_onMoraleStateChanged;
+});

--- a/mod_modular_vanilla/hooks/skills/traits/oath_of_valor_trait.nut
+++ b/mod_modular_vanilla/hooks/skills/traits/oath_of_valor_trait.nut
@@ -1,0 +1,7 @@
+::ModularVanilla.MH.hook("scripts/skills/traits/oath_of_valor_trait", function(q) {
+	q.onUpdate = @(__original) { function onUpdate( _properties )
+	{
+		__original(_properties);
+		_properties.MV_ForbiddenMoraleStates.push(::Const.MoraleState.Fleeing);
+	}}.onUpdate;
+});


### PR DESCRIPTION
This PR modularizes the following vanilla functionality:
- `actor.checkMorale`
- `actor.setMorale`
- `player.setMorale`

It also adds 2 new features:
- Ability for skills to modify Resolve during morale check based on the `_change` and `_type` of the morale check.
- Ability for skills to specify which morale states an actor is forbidden to have.

Using these systems, various vanilla perks/oaths/traits etc. have been hooked to use these modular systems to apply their effects instead of them being hard-coded in various places.