### PR TITLE
feat: add onBeforeAnySkillAdded event for skills

### DIFF
--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -628,10 +628,27 @@
 	{
 		return true;
 	}}.MV_onBeforeAnySkillAdded;
+
+	q.MV_onAnySkillAdded <- { function MV_onAnySkillAdded( _skill )
+	{
+	}}.MV_onAnySkillAdded;
 });
 
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
+	::ModularVanilla.MH.hookTree("scripts/skills/skill", function(q) {
+		// MV: Changed
+		// part of MV_onAnySkillAdded skill_container event
+		q.onAdded = @(__original) { function onAdded()
+		{
+			__original();
+			// Ensure that the skill didn't remove itself during its addition.
+			if (!this.isGarbage())
+			{
+				this.getContainer().MV_onAnySkillAdded(this);
+			}
+		}}.onAdded;
+	});
 	::ModularVanilla.MH.hook("scripts/skills/skill", function(q) {
 		// MV: Changed
 		// part of affordability preview system

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -619,6 +619,15 @@
 	q.onCostsPreview <- { function onCostsPreview( _costsPreview )
 	{
 	}}.onCostsPreview;
+
+	// MV: Added
+	// part of MV_onBeforeAnySkillAdded skill_container event.
+	// Return true: allow _skill to be added to the container.
+	// Return false: don't allow _skill to be added to the container.
+	q.MV_onBeforeAnySkillAdded <- { function MV_onBeforeAnySkillAdded( _skill )
+	{
+		return true;
+	}}.MV_onBeforeAnySkillAdded;
 });
 
 

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -56,6 +56,24 @@
 		this.m.IsUpdating = wasUpdating;
 		return ret;
 	}}.MV_onBeforeAnySkillAdded;
+
+	// MV: Added
+	// part of MV_onAnySkillAdded skill_container event
+	// Is called via a hookTree on skill.onAdded
+	q.MV_onAnySkillAdded <- { function MV_onAnySkillAdded( _skill )
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+		foreach (skill in this.m.Skills)
+		{
+			if (!skill.isGarbage())
+			{
+				skill.MV_onAnySkillAdded(_skill)
+			}
+		}
+		this.m.IsUpdating = wasUpdating;
+		this.update();
+	}}.MV_onAnySkillAdded;
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {

--- a/mod_modular_vanilla/hooks/skills/skill_container.nut
+++ b/mod_modular_vanilla/hooks/skills/skill_container.nut
@@ -32,6 +32,30 @@
 		}
 		this.m.IsUpdating = wasUpdating;
 	}}.onCostsPreview;
+
+	// MV: Added
+	// part of MV_onBeforeAnySkillAdded skill_container event.
+	// The event is triggered via skill_container.add BEFORE the skill is added.
+	// If any existing skill returns `false`, then the skill will not be added to the container.
+	q.MV_onBeforeAnySkillAdded <- { function MV_onBeforeAnySkillAdded( _skill )
+	{
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+		local ret = true;
+		foreach (skill in this.m.Skills)
+		{
+			if (!skill.isGarbage())
+			{
+				if (!skill.MV_onBeforeAnySkillAdded(_skill))
+				{
+					ret = false;
+					break;
+				}
+			}
+		}
+		this.m.IsUpdating = wasUpdating;
+		return ret;
+	}}.MV_onBeforeAnySkillAdded;
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {
@@ -68,5 +92,15 @@
 			this.getActor().resetPreview();
 			return __original();
 		}}.onCombatFinished;
+
+		// MV: Changed
+		// part of MV_onBeforeAnySkillAdded skill_container event.
+		q.add = @(__original) { function add( _skill, _order = 0 )
+		{
+			if (this.MV_onBeforeAnySkillAdded(_skill))
+			{
+				__original(_skill, _order);
+			}
+		}}.add;
 	});
 });


### PR DESCRIPTION
- Allows existing skills to modify the parameters of the new skill that is going to be added.
- Allows existing skills to prevent addition of certain skills to the container.

EDIT:
Based on my comments below, I have also added an `MV_onAnySkillAdded` event.