### PR TITLE
feat: add ability for origins to customize shop list in settlements

### DIFF
--- a/mod_modular_vanilla/hooks/entity/world/settlement.nut
+++ b/mod_modular_vanilla/hooks/entity/world/settlement.nut
@@ -1,0 +1,11 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function () {
+	::ModularVanilla.MH.hook("scripts/entity/world/settlement", function (q) {
+		// MV: Changed
+		// Part of starting_scenario.MV_onUpdateShopList event
+		q.onUpdateShopList = @(__original) { function onUpdateShopList( _buildingID, _list )
+		{
+			__original(_buildingID, _list);
+			::World.Assets.getOrigin().MV_onUpdateShopList(this, _buildingID, _list);
+		}}.onUpdateShopList;
+	});
+});

--- a/mod_modular_vanilla/hooks/scenarios/world/starting_scenario.nut
+++ b/mod_modular_vanilla/hooks/scenarios/world/starting_scenario.nut
@@ -19,6 +19,13 @@
 	q.MV_onLocationEntered <- { function MV_onLocationEntered( _location )
 	{
 	}}.MV_onLocationEntered;
+
+	// MV: Added
+	// Part of starting_scenario.MV_onUpdateShopList event
+	// Called from settlement.onUpdateShopList
+	q.MV_onUpdateShopList <- { function MV_onUpdateShopList( _settlement, _buildingID, _list )
+	{
+	}}.MV_onUpdateShopList;
 });
 
 ::ModularVanilla.QueueBucket.VeryLate.push(function() {


### PR DESCRIPTION
This allows origins to add/remove items from shop, or to adjust their prices and rarity.

A use case is in the Old Swordmaster origin to have a chance for named items spawned in shops to be replaced with named swords.