### PR TITLE
feat: add ability to modify skill costs based on target

### DIFF
--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -13,10 +13,179 @@
 				::Tactical.State.cancelCurrentAction();
 			}
 		}}.onRemoved;
+
+		// MV: Changed
+		// part of affordability preview system
+		// Set the skill's MV_SelectedTarget and then re-make the
+		// costs preview. This allows skills to show different costs based on target.
+		q.onTargetSelected = @(__original) { function onTargetSelected( _targetTile )
+		{
+			__original(_targetTile);
+
+			this.m.MV_SelectedTarget = _targetTile;
+
+			::Tactical.TurnSequenceBar.setActiveEntityCostsPreview({
+				ActionPoints = this.getActionPointCost(),
+				Fatigue = this.getFatigueCost(),
+				SkillID = this.getID()
+			});
+		}}.onTargetSelected;
+
+		// MV: Changed
+		// part of affordability preview system
+		// Set the skill's MV_SelectedTarget to null and then re-make the
+		// costs preview. This causes the skill to preview show its default costs.
+		q.onTargetDeselected = @(__original) { function onTargetDeselected()
+		{
+			__original();
+
+			if (this.m.MV_SelectedTarget != null)
+			{
+				this.m.MV_SelectedTarget = null;
+				::Tactical.TurnSequenceBar.setActiveEntityCostsPreview({
+					ActionPoints = this.getActionPointCost(),
+					Fatigue = this.getFatigueCost(),
+					SkillID = this.getID()
+				});
+			}
+		}}.onTargetDeselected;
+
+		// MV: Changed
+		// part of affordability preview system
+		// For player-controlled actors we return the original because if this is during
+		// preview then the onTargetSelected function has already set the target. And
+		// if this is during use then the `use` function handles setting the target.
+		// For NPCs we have to set the `MV_SelectedTarget` before calling the original
+		// so that their AI behavior code makes the appropriate skill selections.
+		q.isUsableOn = @(__original) { function isUsableOn( _targetTile, _userTile = null )
+		{
+			if (this.getContainer().getActor().isPlayerControlled())
+				return __original(_targetTile, _userTile);
+
+			local o = this.m.MV_SelectedTarget;
+			this.m.MV_SelectedTarget = _targetTile;
+			local ret = __original(_targetTile, _userTile);
+			this.m.MV_SelectedTarget = o;
+			return ret;
+		}}.isUsableOn;
+
+		// MV: Changed
+		// part of affordability preview system
+		// If a skill has a defined override for "getActionPointCost" or "getFatigueCost"
+		// we assume that it may have different costs for different targets. For such skills,
+		// during AI agent evaluation, we return true only if the skill is affordable for
+		// at least 1 valid target. Otherwise an NPC may select a skill deeming it affordable
+		// based on its default costs, but may then not be able to find any valid target to
+		// use it on due to the dynamic costs (which may be higher).
+		q.isAffordable = @(__original) { function isAffordable()
+		{
+			if (this.m.MV_SelectedTarget != null)
+				return __original();
+
+			local actor = this.getContainer().getActor();
+			// For player controlled characters, the affordability will be handled by overwritten
+			// getActionPointCost() etc. and MV_SelectedTarget. So, for them we return original.
+			// Note: We only check that the agent of this skill's actor is evaluating. This means
+			// that affordability of skills of other actors will still return the original (e.g. if
+			// an NPC checks affordability of skills of other actors during his own behavior evaluation).
+			// A workaround for this can be a global private bool that we flip during `agent.evaluate`.
+			// But this current approach is simpler.
+			if (actor.isPlayerControlled() || !actor.getAIAgent().isEvaluating() || !actor.isPlacedOnMap())
+				return __original();
+
+			// In theory one can do this check during `onAdded` of the skill
+			// and then flip a member Boolean to avoid having to do this check
+			// on every call to isAffordable(). But that will fail in the rare
+			// edge case where some modder adds such a `getActionPointCost()` etc.
+			// function to the skill object AFTER it has been added to an actor.
+			local hasOverride = false;
+			local o = this;
+			do
+			{
+				if ("getActionPointCost" in o || "getFatigueCost" in o)
+				{
+					hasOverride = o.ClassName != "skill";
+					break;
+				}
+				o = o.getdelegate();
+			}
+			while(o != null);
+
+			if (!hasOverride)
+				return __original();
+
+			local tiles = [];
+			local myTile = actor.getTile();
+
+			::Tactical.queryTilesInRange(
+				myTile,
+				this.getMinRange(),
+				this.getMaxRange() + (this.isRanged() ? ::Math.min(myTile.Level, this.getMaxRangeBonus()) : 0),
+				!this.isTargetingActor(),
+				[],
+				@(_tile, _) tiles.push(_tile),
+				null
+			);
+
+			local ret = false;
+
+			foreach (t in tiles)
+			{
+				if (!this.onVerifyTarget(myTile, t))
+					continue;
+
+				this.m.MV_SelectedTarget = t;
+				ret = __original();
+				if (ret)
+				{
+					break;
+				}
+			}
+
+			this.m.MV_SelectedTarget = null;
+			return ret;
+		}}.isAffordable;
+
+		// MV: Changed
+		// part of affordability preview system
+		// Set the MV_SelectedTarget during `use` function as NPCs execute skills
+		// directly by calling the `use` function of the skills. This ensures
+		// that they spend the correct AP/Fatigue cost for using the skill on that target.
+		q.use = @(__original) { function use( _targetTile, _forFree = false )
+		{
+			this.m.MV_SelectedTarget = _targetTile;
+			local ret = __original(_targetTile, _forFree);
+			this.m.MV_SelectedTarget = null;
+			return ret;
+		}}.use;
 	});
 });
 
 ::ModularVanilla.MH.hook("scripts/skills/skill", function (q) {
+	// MV: Added
+	// part of affordability preview system
+	// Is set during `skill.onTargetSelected` and during skill execution functions
+	// i.e. `skill.use` and `tactical_state.executeEntitySkill`.
+	// Points to tactical tile which has been selected as the target for this skill.
+	q.m.MV_SelectedTarget <- null;
+
+	// MV: Added
+	// part of affordability preview system
+	q.MV_getSelectedTarget <- { function MV_getSelectedTarget()
+	{
+		// This is handling an edge case where a player mouses over a target
+		// and then mouses over a UI element without first mousing over
+		// a different tile resulting in the target not being deselected.
+		// This would cause AP costs etc. of skills to be measured using that target
+		// which can give unintended information.
+		if (this.getContainer().getActor().isPlayerControlled())
+		{
+			return ::Cursor.isOverUI() ? null : this.m.MV_SelectedTarget;
+		}
+
+		return this.m.MV_SelectedTarget;
+	}}.MV_getSelectedTarget;
+
 	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/796712966523236445/
 	// Floating point precision problem can sometimes cause `ceil` to increase fatigue cost by 1
 	// To fix this we round the value inside the `ceil` to 1 decimal place before ceiling it.

--- a/mod_modular_vanilla/hooks/skills/skill.nut
+++ b/mod_modular_vanilla/hooks/skills/skill.nut
@@ -10,7 +10,11 @@
 			__original();
 			if (this.getContainer().getActor().isPreviewing())
 			{
+				::logInfo("canceling current action " + ::Tactical.State.m.CurrentActionState);
 				::Tactical.State.cancelCurrentAction();
+				// this.Tactical.getNavigator().clearPath();
+				// this.Tactical.getNavigator().clearVisualisation();
+				// this.Tactical.getHighlighter().clear();
 			}
 		}}.onRemoved;
 
@@ -20,6 +24,7 @@
 		// costs preview. This allows skills to show different costs based on target.
 		q.onTargetSelected = @(__original) { function onTargetSelected( _targetTile )
 		{
+			::logWarning("onTargetSelected " + this.getID());
 			__original(_targetTile);
 
 			this.m.MV_SelectedTarget = _targetTile;
@@ -37,16 +42,19 @@
 		// costs preview. This causes the skill to preview show its default costs.
 		q.onTargetDeselected = @(__original) { function onTargetDeselected()
 		{
+			::logWarning("onTargetDeselected " + this.getID() + " " + this.m.MV_SelectedTarget);
+
 			__original();
 
 			if (this.m.MV_SelectedTarget != null)
 			{
 				this.m.MV_SelectedTarget = null;
-				::Tactical.TurnSequenceBar.setActiveEntityCostsPreview({
-					ActionPoints = this.getActionPointCost(),
-					Fatigue = this.getFatigueCost(),
-					SkillID = this.getID()
-				});
+				if (!::Tactical.State.m.__MV_Suppress)
+					::Tactical.TurnSequenceBar.setActiveEntityCostsPreview({
+						ActionPoints = this.getActionPointCost(),
+						Fatigue = this.getFatigueCost(),
+						SkillID = this.getID()
+					});
 			}
 		}}.onTargetDeselected;
 
@@ -180,7 +188,8 @@
 		// which can give unintended information.
 		if (this.getContainer().getActor().isPlayerControlled())
 		{
-			return ::Cursor.isOverUI() ? null : this.m.MV_SelectedTarget;
+			::logInfo(::Tactical.State.m.SelectedSkillID);
+			return ::Cursor.isOverUI() || ::Tactical.isActive() && (::Tactical.State.m.__MV_IsSettingActionState || ::Tactical.State.m.SelectedSkillID != this.getID()) ? null : this.m.MV_SelectedTarget;
 		}
 
 		return this.m.MV_SelectedTarget;

--- a/mod_modular_vanilla/hooks/states/tactical_state.nut
+++ b/mod_modular_vanilla/hooks/states/tactical_state.nut
@@ -50,6 +50,38 @@
 		q.executeEntitySkill = @(__original) { function executeEntitySkill( _activeEntity, _targetTile )
 		{
 			_activeEntity.resetPreview();
+
+			// Skills may have varying costs depending on their selected target. So, before skill execution
+			// we check the affordability of the skill by setting the selected target to _targetTile.
+			local skill = _activeEntity.getSkills().getSkillByID(this.m.SelectedSkillID);
+			if (skill != null && skill.isTargeted() && skill.verifyTargetAndRange(_targetTile))
+			{
+				// skill.m.MV_SelectedTarget is expected to be null here because
+				// target gets deselected before skill execution, so we have to set it again
+				// here so that the isAffordable check gets the correct costs.
+				local original_SelectedTarget = skill.m.MV_SelectedTarget;
+				skill.m.MV_SelectedTarget = _targetTile;
+
+				if (!skill.isAffordable())
+				{
+					// This is a copy of how vanilla does flashing and sound in `tactical_state.setActionStateByMouseEvent`.
+					::Tactical.TurnSequenceBar.flashProgressbars(!skill.isAffordableBasedOnAP(), !skill.isAffordableBasedOnFatigue());
+					if (this.m.LastFatigueSoundTime + 3.0 < ::Time.getVirtualTimeF())
+					{
+						_activeEntity.playSound(::Const.Sound.ActorEvent.Fatigue, ::Const.Sound.Volume.Actor * _activeEntity.m.SoundVolume[::Const.Sound.ActorEvent.Fatigue]);
+						this.m.LastFatigueSoundTime = ::Time.getVirtualTimeF();
+					}
+
+					// We reset the affordability preview at the start of this function
+					// (to ensure we get costs for usage instead of preview)
+					// therefore, we have to restore it here by selecting the target again.
+					skill.onTargetSelected(_targetTile);
+					return;
+				}
+
+				skill.m.MV_SelectedTarget = original_SelectedTarget;
+			}
+
 			return __original(_activeEntity, _targetTile);
 		}}.executeEntitySkill;
 	});

--- a/mod_modular_vanilla/hooks/states/tactical_state.nut
+++ b/mod_modular_vanilla/hooks/states/tactical_state.nut
@@ -1,4 +1,6 @@
 ::ModularVanilla.MH.hook("scripts/states/tactical_state", function(q) {
+	q.m.__MV_IsSettingActionState <- false;
+	q.m.__MV_Suppress <- false;
 	// Each element in this array is a weakref to an instance of MV_AttackInfo during skill.attackEntity.
 	// The purpose is to allow access to the attackInfo from all functions which
 	// do not get it passed directly e.g. onTargetMissed.
@@ -49,6 +51,8 @@
 		// part of affordability preview system
 		q.executeEntitySkill = @(__original) { function executeEntitySkill( _activeEntity, _targetTile )
 		{
+			::logWarning("executeEntitySkill " + this.m.CurrentActionState);
+			::MSU.Log.printStackTrace();
 			_activeEntity.resetPreview();
 
 			// Skills may have varying costs depending on their selected target. So, before skill execution
@@ -76,6 +80,8 @@
 					// (to ensure we get costs for usage instead of preview)
 					// therefore, we have to restore it here by selecting the target again.
 					skill.onTargetSelected(_targetTile);
+					// this.m.CurrentActionState = null;
+					// this.setActionStateBySkill(_activeEntity, skill);
 					return;
 				}
 
@@ -84,5 +90,55 @@
 
 			return __original(_activeEntity, _targetTile);
 		}}.executeEntitySkill;
+
+		q.setActionStateBySkillIndex = @(__original) { function setActionStateBySkillIndex( _skillIndex )
+		{
+			this.m.__MV_IsSettingActionState = true;
+			__original(_skillIndex);
+			this.m.__MV_IsSettingActionState = false;
+		}}.setActionStateBySkillIndex;
+
+		q.setActionStateBySkillId = @(__original) { function setActionStateBySkillId( _skillId )
+		{
+			this.m.__MV_IsSettingActionState = true;
+			__original(_skillId);
+			this.m.__MV_IsSettingActionState = false;
+		}}.setActionStateBySkillId;
+
+		q.setActionStateBySkill = @(__original) { function setActionStateBySkill( _activeEntity, _skill )
+		{
+			local was = this.m.__MV_IsSettingActionState;
+			this.m.__MV_IsSettingActionState = false;
+			this.m.__MV_Suppress = true;
+
+			// ::MSU.Log.printStackTrace();
+			if (this.m.CurrentActionState == ::Const.Tactical.ActionState.SkillSelected)
+			{
+				__original(_activeEntity, _skill)
+				this.m.__MV_IsSettingActionState = was;
+			}
+			else
+			{
+				__original(_activeEntity, _skill);
+
+				this.m.__MV_IsSettingActionState = was;
+
+				// if (this.m.CurrentActionState == ::Const.Tactical.ActionState.SkillSelected)
+				// {
+				// 	this.updateCursorAndTooltip(true);
+				// }
+			}
+			this.m.__MV_Suppress = false;
+		}}.setActionStateBySkill;
+
+		q.cancelEntitySkill = @(__original) { function cancelEntitySkill( _activeEntity )
+		{
+			local skill = _activeEntity.getSkills().getSkillByID(this.m.SelectedSkillID);
+			if (skill != null)
+			{
+				skill.m.MV_SelectedTarget = null;
+			}
+			__original(_activeEntity);
+		}}.cancelEntitySkill;
 	});
 });

--- a/mod_modular_vanilla/hooks/states/tactical_state.nut
+++ b/mod_modular_vanilla/hooks/states/tactical_state.nut
@@ -115,19 +115,28 @@
 			if (this.m.CurrentActionState == ::Const.Tactical.ActionState.SkillSelected)
 			{
 				__original(_activeEntity, _skill)
-				this.m.__MV_IsSettingActionState = was;
 			}
 			else
 			{
+				// local reload = ::Tooltip.reload;
+				// ::Tooltip.reload = @() null;
+
+				local updateCursorAndTooltip = this.updateCursorAndTooltip;
+				this.updateCursorAndTooltip = @(_skillSelected = false) null;
+
 				__original(_activeEntity, _skill);
 
-				this.m.__MV_IsSettingActionState = was;
+				// ::Tooltip.reload = reload;
+				this.updateCursorAndTooltip = updateCursorAndTooltip;
 
-				// if (this.m.CurrentActionState == ::Const.Tactical.ActionState.SkillSelected)
-				// {
-				// 	this.updateCursorAndTooltip(true);
-				// }
+				if (this.m.CurrentActionState == ::Const.Tactical.ActionState.SkillSelected)
+				{
+					::Tooltip.reload();
+					this.updateCursorAndTooltip(true);
+				}
 			}
+
+			this.m.__MV_IsSettingActionState = was;
 			this.m.__MV_Suppress = false;
 		}}.setActionStateBySkill;
 

--- a/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/mod_modular_vanilla/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -83,6 +83,8 @@
 		// part of affordability preview system
 		q.setActiveEntityCostsPreview = @(__original) { function setActiveEntityCostsPreview( _costsPreview )
 		{
+			::logWarning("setActiveEntityCostsPreview " + ::Tactical.State.m.SelectedSkillID);
+			::MSU.Log.printStackTrace();
 			local activeEntity = this.getActiveEntity();
 			if (activeEntity == null || ::getModSetting("mod_msu", "ExpandedSkillTooltips").getValue() == false)
 				return __original(_costsPreview);
@@ -138,6 +140,8 @@
 		// part of affordability preview system
 		q.resetActiveEntityCostsPreview = @(__original) { function resetActiveEntityCostsPreview()
 		{
+			::logWarning("resetActiveEntityCostsPreview " + ::Tactical.State.m.SelectedSkillID);
+			::MSU.Log.printStackTrace();
 			local activeEntity = this.getActiveEntity();
 			if (activeEntity != null)
 			{
@@ -148,5 +152,12 @@
 			}
 			__original();
 		}}.resetActiveEntityCostsPreview;
+
+		q.convertEntitySkillsToUIData = @(__original) { function convertEntitySkillsToUIData( _id )
+		{
+			::logWarning("convertEntitySkillsToUIData");
+			::MSU.Log.printStackTrace();
+			return __original(_id);
+		}}.convertEntitySkillsToUIData;
 	});
 });


### PR DESCRIPTION
The currently selected target tile of a skill is now stored in the skill and is accessed via `skill.MV_getSelectedTarget()`. It will be null when no target is selected. Otherwise it will return the targeted tile.

In order to have custom costs for different targets, you would add overwrites for `getActionPointCost` and `getFatigueCost` in the skill's script. 
```squirrel
// To have a skill cost +2 AP when targeting a Lindwurm.
function getActionPointCost()
{
   local ret = this.skill.getActionPointCost();

   if (this.MV_getSelectedTarget() != null && ::MSU.isKindOf(this.MV_getSelectedTarget().getEntity(), "lindwurm"))
   {
      ret += 2;
   }

  return 2;
}
// The `getFatigueCost()` function can be done in the same way.
```