### PR TITLE
fix(vanilla): location template being overwritten

### DIFF
--- a/mod_modular_vanilla/hooks/config/tactical.nut
+++ b/mod_modular_vanilla/hooks/config/tactical.nut
@@ -23,3 +23,17 @@
 	MV_PropertiesForDefense = null, // target skill_container.buildPropertiesForDefense
 	MV_PropertiesForBeingHit = null // target skill_container.buildPropertiesForBeingHit
 });
+
+// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753627754294975/
+// In some cases in vanilla (e.g. `arena_contract` the LocationTemplate.Template array inside
+// is not properly cloned and ends up having an overwritten value. We fix this by overwriting
+// the _cloned metamethod to recursively deepclone the entire template.
+::Const.Tactical.LocationTemplate.setdelegate({
+	function _cloned( _original )
+	{
+		foreach (k, v in _original)
+		{
+			this[k] = ::MSU.deepClone(v);
+		}
+	}
+});


### PR DESCRIPTION
In some cases in vanilla (e.g. `arena_contract` the LocationTemplate.Template array inside is not properly cloned and ends up having an overwritten value. We fix this by overwriting the _cloned metamethod to recursively deepclone the entire template.

Bug report: https://steamcommunity.com/app/365360/discussions/1/841753627754294975/