### PR TITLE
fix(vanilla): use TimeUnit.Virtual in skill usage instead of Real

### DIFF
--- a/mod_modular_vanilla/hooks/skills/actives/corpse_explosion_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/corpse_explosion_skill.nut
@@ -1,0 +1,29 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/corpse_explosion_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		local isFleshCradle = _targetTile.getEntity() != null && _targetTile.getEntity().getType() == ::Const.EntityType.FleshCradle && !_targetTile.getEntity().getIsDestroyed();
+
+		if (isFleshCradle)
+		{
+			// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+			::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onDestroyFleshCradle.bindenv(this), {
+				FleshCradle = _targetTile.getEntity()
+			});
+		}
+		else
+		{
+			this.onRemoveCorpse(_targetTile);
+		}
+
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+			Skill = this,
+			TargetTile = _targetTile,
+			User = _user
+		});
+		return true;
+	}}.onUse;
+});

--- a/mod_modular_vanilla/hooks/skills/actives/explode_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/explode_skill.nut
@@ -1,0 +1,19 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/explode_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		if (!_user.isHiddenToPlayer())
+		{
+			::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " explodes into shrapnel of bone!");
+		}
+
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 300, function ( _user )
+		{
+			_user.kill();
+		}, _user);
+		return true;
+	}}.onUse;
+});

--- a/mod_modular_vanilla/hooks/skills/actives/fire_mortar_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/fire_mortar_skill.nut
@@ -1,0 +1,41 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/fire_mortar_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		this.m.Cooldown = 2;
+		this.m.AffectedTiles = this.getAffectedTiles(_targetTile);
+
+		foreach( tile in this.m.AffectedTiles )
+		{
+			tile.Properties.IsMarkedForImpact = true;
+			tile.spawnDetail(this.getImpactSprite(), ::Const.Tactical.DetailFlag.SpecialOverlay, false, true);
+		}
+
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 1000, this.onSpawnFireEffect.bindenv(this), this);
+
+		if (!_user.isHiddenToPlayer())
+		{
+			::Tactical.EventLog.log(::Const.UI.getColorizedEntityName(_user) + " fires a shell high in the air");
+		}
+
+		return true;
+	}}.onUse;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.updateImpact = @() { function updateImpact()
+	{
+		if (this.m.AffectedTiles.len() != 0)
+		{
+			this.getContainer().getActor().setActionPoints(0);
+			// Change to use MSU.Array.rand for better readability
+			::Sound.play(::MSU.Array.rand(this.m.SoundOnHit), 1.0, this.m.AffectedTiles[0].Pos);
+			// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+			::Time.scheduleEvent(::TimeUnit.Virtual, 1400, this.onImpact.bindenv(this), this);
+		}
+	}}.updateImpact;
+});

--- a/mod_modular_vanilla/hooks/skills/actives/geomancy_once_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/geomancy_once_skill.nut
@@ -1,0 +1,15 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/geomancy_once_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.updateImpact = @(__original) { function updateImpact()
+	{
+		if (this.m.AffectedTiles.len() != 0)
+		{
+			// Change to use MSU.Array.rand for better readability
+			::Sound.play(::MSU.Array.rand(this.m.SoundOnHit), 1.0, this.m.AffectedTiles[0].Pos);
+			// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+			::Time.scheduleEvent(::TimeUnit.Virtual, 100, this.onLowerTiles.bindenv(this), this);
+		}
+	}}.updateImpact;
+});

--- a/mod_modular_vanilla/hooks/skills/actives/kraken_ensnare_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/kraken_ensnare_skill.nut
@@ -1,0 +1,19 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/kraken_ensnare_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		_user.sinkIntoGround(0.75);
+		_user.getSkills().setBusy(true);
+		_user.m.IsAbleToDie = false;
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 800, this.onNetSpawn.bindenv(this), {
+			User = _user,
+			Skill = this,
+			TargetEntity = _targetTile.getEntity(),
+			LoseHitpoints = true
+		});
+		return true;
+	}}.onUse;
+});

--- a/mod_modular_vanilla/hooks/skills/actives/lightning_storm_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/lightning_storm_skill.nut
@@ -1,0 +1,73 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/lightning_storm_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.updateImpact = @() { function updateImpact()
+	{
+		if (this.m.AffectedTiles.len() != 0)
+		{
+			// Change to use MSU.Array.rand for better readability
+			::Sound.play(::MSU.Array.rand(this.m.SoundOnHit), 0.8);
+			// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+			::Time.scheduleEvent(::TimeUnit.Virtual, 600, this.onImpact.bindenv(this), this);
+		}
+	}}.updateImpact;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onImpact = @() { function onImpact( _tag )
+	{
+		::Tactical.EventLog.log("Lightning strikes the battlefield");
+		::Tactical.getCamera().quake(::createVec(0, -1.0), 6.0, 0.16, 0.35);
+		local actor = this.getContainer().getActor();
+
+		foreach (i, t in _tag.m.AffectedTiles)
+		{
+			::Time.scheduleEvent(::TimeUnit.Virtual, i * 30, function ( _data )
+			{
+				local tile = _data.Tile;
+
+				for( local i = 0; i < ::Const.Tactical.LightningParticles.len(); i = ++i )
+				{
+					::Tactical.spawnParticleEffect(true, ::Const.Tactical.LightningParticles[i].Brushes, tile, ::Const.Tactical.LightningParticles[i].Delay, ::Const.Tactical.LightningParticles[i].Quantity, ::Const.Tactical.LightningParticles[i].LifeTimeQuantity, ::Const.Tactical.LightningParticles[i].SpawnRate, ::Const.Tactical.LightningParticles[i].Stages);
+				}
+
+				tile.clear(::Const.Tactical.DetailFlag.SpecialOverlay);
+				tile.Properties.IsMarkedForImpact = false;
+
+				if ((tile.IsEmpty || tile.IsOccupiedByActor) && tile.Type != ::Const.Tactical.TerrainType.ShallowWater && tile.Type != ::Const.Tactical.TerrainType.DeepWater)
+				{
+					tile.clear(::Const.Tactical.DetailFlag.Scorchmark);
+					tile.spawnDetail("impact_decal", ::Const.Tactical.DetailFlag.Scorchmark, false, true);
+				}
+
+				if (tile.IsOccupiedByActor && !_data.User.isAlliedWith(tile.getEntity()))
+				{
+					local target = tile.getEntity();
+					local hitInfo = clone ::Const.Tactical.HitInfo;
+					hitInfo.DamageRegular = ::Math.rand(25, 50);
+					hitInfo.DamageArmor = hitInfo.DamageRegular * 1.0;
+					hitInfo.DamageDirect = 0.75;
+					hitInfo.BodyPart = 0;
+					hitInfo.FatalityChanceMult = 0.0;
+					hitInfo.Injuries = ::Const.Injury.BurningBody;
+					target.onDamageReceived(_data.User, _data.Skill, hitInfo);
+				}
+			}, {
+				Tile = t,
+				Skill = this,
+				User = actor
+			});
+		}
+
+		_tag.m.AffectedTiles = [];
+
+		if (_tag.m.HasCooldownAfterImpact)
+		{
+			_tag.m.Cooldown = 1;
+		}
+
+		::Tactical.Entities.getFlags().set("LightningStrikesActive", ::Math.max(0, ::Tactical.Entities.getFlags().getAsInt("LightningStrikesActive") - 1));
+	}}.onImpact;
+});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_acid_flask.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_acid_flask.nut
@@ -7,4 +7,29 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}}.onAfterUpdate;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		local targetEntity = _targetTile.getEntity();
+
+		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
+		{
+			local flip = !this.m.IsProjectileRotated && targetEntity.getPos().X > _user.getPos().X;
+
+			if (_user.getTile().getDistanceTo(targetEntity.getTile()) >= ::Const.Combat.SpawnProjectileMinDist)
+			{
+				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), targetEntity.getTile(), 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+			}
+		}
+
+		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 200, this.onApplyAcid.bindenv(this), {
+			Skill = this,
+			TargetTile = _targetTile
+		});
+	}}.onUse;
 });

--- a/mod_modular_vanilla/hooks/skills/actives/throw_acid_flask.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_acid_flask.nut
@@ -15,19 +15,22 @@
 	{
 		local targetEntity = _targetTile.getEntity();
 
+		// Minor "fix": We sync the scheduleEvent delay to be exactly the delay from spawnProjectileEffect
+		// This also ensures that if Projectile is not shown, then there is no delay.
+		// vanilla delay is 200.
+		local delay = 1;
 		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
 		{
-			local flip = !this.m.IsProjectileRotated && targetEntity.getPos().X > _user.getPos().X;
-
 			if (_user.getTile().getDistanceTo(targetEntity.getTile()) >= ::Const.Combat.SpawnProjectileMinDist)
 			{
-				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), targetEntity.getTile(), 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+				local flip = !this.m.IsProjectileRotated && targetEntity.getPos().X > _user.getPos().X;
+				delay = ::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), targetEntity.getTile(), 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
 			}
 		}
 
 		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
 		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
-		::Time.scheduleEvent(::TimeUnit.Virtual, 200, this.onApplyAcid.bindenv(this), {
+		::Time.scheduleEvent(::TimeUnit.Virtual, delay, this.onApplyAcid.bindenv(this), {
 			Skill = this,
 			TargetTile = _targetTile
 		});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_daze_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_daze_bomb_skill.nut
@@ -13,19 +13,22 @@
 	// to issues. We fix it by using TimeUnit.Virtual instead.
 	q.onUse = @() { function onUse( _user, _targetTile )
 	{
+		// Minor "fix": We sync the scheduleEvent delay to be exactly the delay from spawnProjectileEffect
+		// This also ensures that if Projectile is not shown, then there is no delay.
+		// vanilla delay is 250.
+		local delay = 1;
 		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
 		{
-			local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
-
 			if (_user.getTile().getDistanceTo(_targetTile) >= ::Const.Combat.SpawnProjectileMinDist)
 			{
-				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+				local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
+				delay = ::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
 			}
 		}
 
 		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
 		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
-		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+		::Time.scheduleEvent(::TimeUnit.Virtual, delay, this.onApply.bindenv(this), {
 			Skill = this,
 			TargetTile = _targetTile
 		});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_daze_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_daze_bomb_skill.nut
@@ -7,4 +7,27 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}}.onAfterUpdate;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
+		{
+			local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
+
+			if (_user.getTile().getDistanceTo(_targetTile) >= ::Const.Combat.SpawnProjectileMinDist)
+			{
+				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+			}
+		}
+
+		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+			Skill = this,
+			TargetTile = _targetTile
+		});
+	}}.onUse;
 });

--- a/mod_modular_vanilla/hooks/skills/actives/throw_fire_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_fire_bomb_skill.nut
@@ -13,19 +13,22 @@
 	// to issues. We fix it by using TimeUnit.Virtual instead.
 	q.onUse = @() { function onUse( _user, _targetTile )
 	{
+		// Minor "fix": We sync the scheduleEvent delay to be exactly the delay from spawnProjectileEffect
+		// This also ensures that if Projectile is not shown, then there is no delay.
+		// vanilla delay is 250
+		local delay = 1;
 		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
 		{
-			local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
-
 			if (_user.getTile().getDistanceTo(_targetTile) >= ::Const.Combat.SpawnProjectileMinDist)
 			{
-				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+				local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
+				delay = ::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
 			}
 		}
 
 		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
 		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
-		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+		::Time.scheduleEvent(::TimeUnit.Virtual, delay, this.onApply.bindenv(this), {
 			Skill = this,
 			User = _user,
 			TargetTile = _targetTile

--- a/mod_modular_vanilla/hooks/skills/actives/throw_fire_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_fire_bomb_skill.nut
@@ -7,4 +7,28 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}}.onAfterUpdate;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
+		{
+			local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
+
+			if (_user.getTile().getDistanceTo(_targetTile) >= ::Const.Combat.SpawnProjectileMinDist)
+			{
+				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+			}
+		}
+
+		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+			Skill = this,
+			User = _user,
+			TargetTile = _targetTile
+		});
+	}}.onUse;
 });

--- a/mod_modular_vanilla/hooks/skills/actives/throw_holy_water.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_holy_water.nut
@@ -15,19 +15,22 @@
 	{
 		local targetEntity = _targetTile.getEntity();
 
+		// Minor "fix": We sync the scheduleEvent delay to be exactly the delay from spawnProjectileEffect
+		// This also ensures that if Projectile is not shown, then there is no delay.
+		// vanilla delay is 200.
+		local delay = 1;
 		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
 		{
-			local flip = !this.m.IsProjectileRotated && targetEntity.getPos().X > _user.getPos().X;
-
 			if (_user.getTile().getDistanceTo(targetEntity.getTile()) >= ::Const.Combat.SpawnProjectileMinDist)
 			{
-				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), targetEntity.getTile(), 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+				local flip = !this.m.IsProjectileRotated && targetEntity.getPos().X > _user.getPos().X;
+				delay = ::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), targetEntity.getTile(), 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
 			}
 		}
 
 		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
 		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
-		::Time.scheduleEvent(::TimeUnit.Virtual, 200, this.onApplyEffect.bindenv(this), {
+		::Time.scheduleEvent(::TimeUnit.Virtual, delay, this.onApplyEffect.bindenv(this), {
 			Skill = this,
 			TargetTile = _targetTile
 		});

--- a/mod_modular_vanilla/hooks/skills/actives/throw_holy_water.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_holy_water.nut
@@ -7,4 +7,29 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}}.onAfterUpdate;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		local targetEntity = _targetTile.getEntity();
+
+		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
+		{
+			local flip = !this.m.IsProjectileRotated && targetEntity.getPos().X > _user.getPos().X;
+
+			if (_user.getTile().getDistanceTo(targetEntity.getTile()) >= ::Const.Combat.SpawnProjectileMinDist)
+			{
+				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), targetEntity.getTile(), 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+			}
+		}
+
+		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 200, this.onApplyEffect.bindenv(this), {
+			Skill = this,
+			TargetTile = _targetTile
+		});
+	}}.onUse;
 });

--- a/mod_modular_vanilla/hooks/skills/actives/throw_net.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_net.nut
@@ -7,4 +7,61 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}}.onAfterUpdate;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		local targetEntity = _targetTile.getEntity();
+
+		if (!targetEntity.getCurrentProperties().IsImmuneToRoot)
+		{
+			if (this.m.SoundOnHit.len() != 0)
+			{
+				// Change to use MSU.Array.rand for better readability
+				::Sound.play(::MSU.Array.rand(this.m.SoundOnHit), ::Const.Sound.Volume.Skill, targetEntity.getPos());
+			}
+
+			_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+			targetEntity.getSkills().add(this.new("scripts/skills/effects/net_effect"));
+			local breakFree = this.new("scripts/skills/actives/break_free_skill");
+			breakFree.m.Icon = "skills/active_74.png";
+			breakFree.m.IconDisabled = "skills/active_74_sw.png";
+			breakFree.m.Overlay = "active_74";
+			breakFree.m.SoundOnUse = this.m.SoundOnHitHitpoints;
+
+			if (this.m.IsReinforced)
+			{
+				breakFree.setDecal("net_destroyed_02");
+				breakFree.setChanceBonus(-15);
+			}
+			else
+			{
+				breakFree.setDecal("net_destroyed");
+				breakFree.setChanceBonus(0);
+			}
+
+			targetEntity.getSkills().add(breakFree);
+			local effect = ::Tactical.spawnSpriteEffect(this.m.IsReinforced ? "bust_net_02" : "bust_net", ::createColor("#ffffff"), _targetTile, 0, 10, 1.0, targetEntity.getSprite("status_rooted").Scale, 100, 100, 0);
+			local flip = !targetEntity.isAlliedWithPlayer();
+			effect.setHorizontalFlipping(flip);
+			// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+			::Time.scheduleEvent(::TimeUnit.Virtual, 200, this.onNetSpawn.bindenv(this), {
+				TargetEntity = targetEntity,
+				IsReinforced = this.m.IsReinforced
+			});
+		}
+		else
+		{
+			if (this.m.SoundOnMiss.len() != 0)
+			{
+				// Change to use MSU.Array.rand for better readability
+				::Sound.play(::MSU.Array.rand(this.m.SoundOnMiss), ::Const.Sound.Volume.Skill, targetEntity.getPos());
+			}
+
+			_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+			return false;
+		}
+	}}.onUse;
 });

--- a/mod_modular_vanilla/hooks/skills/actives/throw_smoke_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_smoke_bomb_skill.nut
@@ -7,4 +7,28 @@
 			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
 		}
 	}}.onAfterUpdate;
+
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
+		{
+			local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
+
+			if (_user.getTile().getDistanceTo(_targetTile) >= ::Const.Combat.SpawnProjectileMinDist)
+			{
+				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+			}
+		}
+
+		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
+		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+			Skill = this,
+			User = _user,
+			TargetTile = _targetTile
+		});
+	}}.onUse;
 });

--- a/mod_modular_vanilla/hooks/skills/actives/throw_smoke_bomb_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/throw_smoke_bomb_skill.nut
@@ -13,19 +13,22 @@
 	// to issues. We fix it by using TimeUnit.Virtual instead.
 	q.onUse = @() { function onUse( _user, _targetTile )
 	{
+		// Minor "fix": We sync the scheduleEvent delay to be exactly the delay from spawnProjectileEffect
+		// This also ensures that if Projectile is not shown, then there is no delay.
+		// vanilla delay is 250.
+		local delay = 1;
 		if (this.m.IsShowingProjectile && this.m.ProjectileType != 0)
 		{
-			local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
-
 			if (_user.getTile().getDistanceTo(_targetTile) >= ::Const.Combat.SpawnProjectileMinDist)
 			{
-				::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
+				local flip = !this.m.IsProjectileRotated && _targetTile.Pos.X > _user.getPos().X;
+				delay = ::Tactical.spawnProjectileEffect(::Const.ProjectileSprite[this.m.ProjectileType], _user.getTile(), _targetTile, 1.0, this.m.ProjectileTimeScale, this.m.IsProjectileRotated, flip);
 			}
 		}
 
 		_user.getItems().unequip(_user.getItems().getItemAtSlot(::Const.ItemSlot.Offhand));
 		// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
-		::Time.scheduleEvent(::TimeUnit.Virtual, 250, this.onApply.bindenv(this), {
+		::Time.scheduleEvent(::TimeUnit.Virtual, delay, this.onApply.bindenv(this), {
 			Skill = this,
 			User = _user,
 			TargetTile = _targetTile

--- a/mod_modular_vanilla/hooks/skills/actives/web_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/web_skill.nut
@@ -1,0 +1,43 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/web_skill", function(q) {
+	// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/
+	// Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead
+	// to issues. We fix it by using TimeUnit.Virtual instead.
+	q.onUse = @() { function onUse( _user, _targetTile )
+	{
+		this.m.Cooldown = 3;
+		local targetEntity = _targetTile.getEntity();
+
+		if (!targetEntity.getCurrentProperties().IsImmuneToRoot)
+		{
+			if (this.m.SoundOnHit.len() != 0)
+			{
+				// Change to use MSU.Array.rand for better readability
+				::Sound.play(::MSU.Array.rand(this.m.SoundOnHit), ::Const.Sound.Volume.Skill, targetEntity.getPos());
+			}
+
+			targetEntity.getSkills().add(::new("scripts/skills/effects/web_effect"));
+			local breakFree = ::new("scripts/skills/actives/break_free_skill");
+			breakFree.setDecal("web_destroyed");
+			breakFree.m.Icon = "skills/active_113.png";
+			breakFree.m.IconDisabled = "skills/active_113_sw.png";
+			breakFree.m.Overlay = "active_113";
+			breakFree.m.SoundOnUse = this.m.SoundOnHitHitpoints;
+			targetEntity.getSkills().add(breakFree);
+			local effect = ::Tactical.spawnSpriteEffect("bust_web2", ::createColor("#ffffff"), _targetTile, 0, 4, 1.0, targetEntity.getSprite("status_rooted").Scale, 100, 100, 0);
+			local flip = !targetEntity.isAlliedWithPlayer();
+			effect.setHorizontalFlipping(flip);
+			// This is the fix i.e. we use TimeUnit.Virtual instead of vanilla TimeUnit.Real
+			::Time.scheduleEvent(::TimeUnit.Virtual, 200, this.onNetSpawn.bindenv(this), targetEntity);
+		}
+		else
+		{
+			if (this.m.SoundOnMiss.len() != 0)
+			{
+				// Change to use MSU.Array.rand for better readability
+				::Sound.play(::MSU.Array.rand(this.m.SoundOnMiss), ::Const.Sound.Volume.Skill, targetEntity.getPos());
+			}
+
+			return false;
+		}
+	}}.onUse;
+});


### PR DESCRIPTION
Vanilla uses TimeUnit.Real to schedule stuff during skill usage, which can lead to issues. We fix it by using TimeUnit.Virtual instead.

Bug report: https://steamcommunity.com/app/365360/discussions/1/841753826211060610/