### PR TITLE
Fix serialize tavern rumors

### DIFF
--- a/mod_modular_vanilla/hooks/entity/world/settlements/buildings/tavern_building.nut
+++ b/mod_modular_vanilla/hooks/entity/world/settlements/buildings/tavern_building.nut
@@ -1,0 +1,40 @@
+::ModularVanilla.QueueBucket.VeryLate.push(function () {
+	::ModularVanilla.MH.hook("scripts/entity/world/settlements/buildings/tavern_building", function (q) {
+		q.m.MV_LastRumorFlag <- "MV_LastRumorFlag";
+
+		q.onSettlementEntered = @(__original) { function onSettlementEntered()
+		{
+			__original();
+
+			// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/570415959124302855/
+			// Serialize the value of this.m.LastRumor in the settlement flags. Vanilla sets this field to `""` upon
+			// entering the settlement if a certain amount of time has passed. So we need to update our flag accordingly.
+			// We cannot set the LastRumor flag during onSerialize, because world_entity flags are serialized before buildings are serialized.
+			this.getSettlement().getFlags().set(this.m.MV_LastRumorFlag, this.m.LastRumor);
+		}}.onSettlementEntered;
+
+		q.getRumor = @(__original) { function getRumor( _isPaidFor = false )
+		{
+			local ret = __original(_isPaidFor);
+
+			// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/570415959124302855/
+			// Serialize the value of this.m.LastRumor in the settlement flags, whenever it is changed by the tavern.
+			// We cannot do that during onSerialize, because world_entity flags are serialized before buildings are serialized.
+			this.getSettlement().getFlags().set(this.m.MV_LastRumorFlag, this.m.LastRumor);
+
+			return ret;
+		}}.getRumor;
+
+		q.onDeserialize = @(__original) { function onDeserialize( _in )
+		{
+			__original(_in);
+
+			// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/570415959124302855/
+			// Deserialize the value of this.m.LastRumor from the settlement flags.
+			if (this.getSettlement().getFlags().has(this.m.MV_LastRumorFlag))
+			{
+				this.m.LastRumor = this.getSettlement().getFlags().get(this.m.MV_LastRumorFlag);
+			}
+		}}.onDeserialize;
+	});
+});


### PR DESCRIPTION
Vanilla keeps track of the last rumor you received for each Tavern in `this.m.LastRumor`
This rumor is shown to you every time you revisit that same tavern until it times out (usually after 24h)

## Problem
Currently, whenever you reload your game, you get a fresh, free tavern rumor in ever tavern.
And the tavern rumor you had in your previous playthrough is gone.

As a result you can cheese the game by endlessly reloading the game to cycle through every possible tavern rumor for a given tavern.

Meanwhile, vanilla does remember between savegames, when you received your last tavern rumor and how many rumors you already paid for.