### PR TITLE
fix: quick shot not having -1 range compared to that of its item

### DIFF
--- a/mod_modular_vanilla/hooks/skills/actives/quick_shot.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/quick_shot.nut
@@ -15,7 +15,7 @@
 	// certain skills e.g. fire_handgonne_skill to set the MaxRange of the skill to that of the item.
 	q.onItemSet = @(__original) { function onItemSet()
 	{
-		this.m.MaxRange = this.getItem().getRangeMax();
+		this.m.MaxRange = this.getItem().getRangeMax() - 1;
 		__original();
 	}}.onItemSet;
 });


### PR DESCRIPTION
Vanilla reduces Quick Shot range by 1 compared to its item.