### PR TITLE
feat: convert vanilla mastery effects in assault_skill to be incremental

### DIFF
--- a/mod_modular_vanilla/hooks/skills/actives/assault_skill.nut
+++ b/mod_modular_vanilla/hooks/skills/actives/assault_skill.nut
@@ -1,0 +1,14 @@
+::ModularVanilla.MH.hook("scripts/skills/actives/assault_skill", function(q) {
+	// Convert the vanilla method of "setting" certain fields to instead be incremental changes
+	q.onAfterUpdate = @() { function onAfterUpdate( _properties )
+	{
+		if (_properties.IsSpecializedInPolearms)
+		{
+			this.m.FatigueCostMult *= ::Const.Combat.WeaponSpecFatigueMult;
+			if (this.getBaseValue("ActionPointCost") > 5)
+			{
+				this.m.ActionPointCost -= 1;
+			}
+		}
+	}}.onAfterUpdate;
+});


### PR DESCRIPTION
This skill was an addition from vanilla 1.5.2.2
The other skill on that same polearm (`smite_skill`) has already been streamlined by module vanilla